### PR TITLE
Housekeeping fixes (makefile/unit test cruft)

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -45,4 +45,4 @@ test-flcl.x: test-flcl-cxx.o test-flcl-f.o test-flcl-main.o libflcl.a
 	$(FC) $(FSTD) $(DEBUG) -I$(TESTSRCDIR)/ test-flcl-cxx.o test-flcl-f.o test-flcl-main.o -L. -lflcl $(KOKKOS_LIB) -lstdc++ -o test-flcl.x
 
 clean:
-	rm -f ./*.o ./*.mod ./libflcl.a
+	rm -f ./*.o ./*.x ./*.mod ./libflcl.a

--- a/test/test-flcl-main.f90
+++ b/test/test-flcl-main.f90
@@ -7,27 +7,6 @@ program test_flcl_main
 
   implicit none
 
-  integer :: m
-  integer :: ii
-  integer :: refine_count
-  integer :: refine_steps
-  real(c_double) :: percentage
-  integer(c_int32_t) ::dimension
-  integer :: block_size
-  integer(c_int32_t) :: ntop
-  integer(c_int32_t) :: nchunks
-  integer(c_int32_t), dimension(:), pointer :: mesh_ids
-  integer(c_int32_t), dimension(:), allocatable, target :: mesh_status
-  integer(c_int32_t), dimension(:), allocatable, target :: new_mesh_status
-  integer(c_int32_t), dimension(:), pointer :: p_mesh_status
-  integer(c_int32_t), dimension(:), pointer :: p_new_mesh_status
-  integer(c_int32_t), dimension(:), pointer :: p_ltop
-  real(c_double), dimension(:), pointer :: array_x
-  real(c_double), dimension(:), pointer :: array_y
-  real(c_double) :: s_val
-  type(c_ptr) :: v_x
-  type(c_ptr) :: v_y
-
   call kokkos_initialize()
 
   call test_ndarray_l_1d()


### PR DESCRIPTION
Merges in fixes:

- Adds executables (*.x) to the clean target in build/Makefile to remove the unit test executable.
- Removes cruft in the unit test main driver function.