### PR TITLE
BLD, TST: get ndarray_l_1d passing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ include(CheckCCompilerFlag)
 #    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 #endif("${isSystemDir}" STREQUAL "-1")
 
+add_link_options(LINKER:--disable-new-dtags)
+
 
 add_library(flcl-fortran
     OBJECT

--- a/ci/flcl-run-ci-darwin-ppc-xl-serial.sh
+++ b/ci/flcl-run-ci-darwin-ppc-xl-serial.sh
@@ -11,6 +11,9 @@ cd $CI_BUILD_DIR
 module load cmake/3.15.3
 module load gcc/7.4.0
 module load ibm/xlc-16.1.1.6-xlf-16.1.1.6
+# one of the important library dirs is not added
+# to LD_LIBRARY path for XL module above:
+setenv LD_LIBRARY_PATH /projects/opt/ppc64le/ibm/xlf-16.1.1.6/lib:$LD_LIBRARY_PATH
 cmake --version
 cmake -DKokkos_DIR=$CI_KOKKOS_PATH \
     -DCMAKE_INSTALL_PREFIX=$CI_INSTALL_DIR $CI_PATH_PREFIX \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,30 +56,26 @@ file(GLOB files "test_*.f90")
 # if cmake 3.17 is supported everywhere
 # list(APPEND CMAKE_CTEST_ARGUMENTS "--output-on-failure")
 
-# foreach(file ${files})
-# 	string(REGEX REPLACE "(^.*/|\\.[^.]*$)" "" file_without_ext ${file})
-#     add_executable(${file_without_ext} ${file})
-#     set(RPATHS "$ENV{LD_LIBRARY_PATH}")
-#     message("****file_without_ext:" ${file_without_ext})
-#     set_target_properties(${file_without_ext} PROPERTIES INSTALL_RPATH ${RPATHS} BUILD_WITH_INSTALL_RPATH True)
-# 	target_link_libraries(${file_without_ext} ${PROJECT_LIBS} FLCL::flcl flcl-testlib)
-#     #add_test(${file_without_ext} ${file_without_ext})
-#     #set_target_properties(${file_without_ext} PROPERTIES LINKER_LANGUAGE Fortran) 
-# 	# set_tests_properties(${file_without_ext}
-# 	# 	PROPERTIES
-# 	# 	PASS_REGULAR_EXPRESSION "Test passed")
-# 	# set_tests_properties(${file_without_ext}
-# 	# 	PROPERTIES
-# 	# 	FAIL_REGULAR_EXPRESSION "(Exception|Test failed)")
-# 	#set_tests_properties(${file_without_ext}
-# 		#PROPERTIES
-#        # TIMEOUT 120)
+foreach(file ${files})
+ 	string(REGEX REPLACE "(^.*/|\\.[^.]*$)" "" file_without_ext ${file})
+    add_executable(${file_without_ext} ${file})
+	target_link_options(${file_without_ext} PRIVATE LINKER:-lxlf90_r)
+    set(RPATHS "$ENV{LD_LIBRARY_PATH}")
+	set_target_properties(${file_without_ext} PROPERTIES 
+						  BUILD_WITH_INSTALL_RPATH True
+						  INSTALL_RPATH ${RPATHS})
+     set_target_properties(${file_without_ext} PROPERTIES INSTALL_RPATH ${RPATHS} BUILD_WITH_INSTALL_RPATH True)
+ 	target_link_libraries(${file_without_ext} ${PROJECT_LIBS} FLCL::flcl flcl-testlib)
+    add_test(${file_without_ext} ${file_without_ext})
+	#set_target_properties(${file_without_ext} PROPERTIES LINKER_LANGUAGE Fortran) 
+ 	# set_tests_properties(${file_without_ext}
+ 	# 	PROPERTIES
+ 	# 	PASS_REGULAR_EXPRESSION "Test passed")
+ 	# set_tests_properties(${file_without_ext}
+ 	# 	PROPERTIES
+ 	# 	FAIL_REGULAR_EXPRESSION "(Exception|Test failed)")
+ 	set_tests_properties(${file_without_ext}
+ 		PROPERTIES
+        TIMEOUT 120)
 
-# endforeach()
-
-add_executable(test_ndarray_l_1d test_ndarray_l_1d.f90)
-target_link_libraries(test_ndarray_l_1d ${PROJECT_LIBS} FLCL::flcl flcl-testlib)
-set(RPATHS "$ENV{LD_LIBRARY_PATH}")
-set_target_properties(test_ndarray_l_1d PROPERTIES 
-                      BUILD_WITH_INSTALL_RPATH True
-                      INSTALL_RPATH ${RPATHS})
+endforeach()


### PR DESCRIPTION
* the generated test/executable, when using XL
toolchain, had the modern RUNPATH set instead
of RPATH, so disable this with --disable-new-dtags
linker option

* LD_LIBRARY_PATH itself did not contain an important
path to some of the XL toolchain shared libraries; namely,
/projects/opt/ppc64le/ibm/xlf-16.1.1.6/lib was missing
so this was added to the FLCL "CI" shell script

* with those adjustments, we no longer need to set
LINKER_LANGUAGE, but it is unfortunate that the Darwin
module is not adding the full complement of LD_LIBRARY_PATH
entries, so this does compromise portability of the "CI" script
obviously