### PR TITLE
Fixes to cmake build system to make installation by spack and target exporting more standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,13 @@
 cmake_minimum_required(VERSION 3.17)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
-project(FLCL VERSION 0.3.0 LANGUAGES Fortran C CXX)
+set(FLCL_MAJOR_VERSION 0)
+set(FLCL_MINOR_VERSION 4)
+set(FLCL_PATCH_VERSION 0)
+set(FLCL_VERSION
+  ${FLCL_MAJOR_VERSION}.${FLCL_MINOR_VERSION}.${FLCL_PATCH_VERSION})
+
+project(flcl VERSION ${FLCLVERSION} LANGUAGES Fortran C CXX)
 
 set(default_build_type "RelWithDebInfo")
 set(BUILD_SHARED_LIBS OFF)
@@ -71,21 +77,21 @@ target_link_libraries(flcl-cxx
         Kokkos::kokkos
 )
 
-add_library(FLCL
+add_library(flcl
     STATIC
         $<TARGET_OBJECTS:flcl-fortran>
         $<TARGET_OBJECTS:flcl-cxx>
 )
-target_include_directories(FLCL
+target_include_directories(flcl
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
         $<INSTALL_INTERFACE:mod>
 )
-target_link_libraries(FLCL
+target_link_libraries(flcl
     INTERFACE
     Kokkos::kokkos
 )
-add_library(FLCL::flcl ALIAS FLCL)
+add_library(flcl::flcl ALIAS flcl)
 
 include(CMakePackageConfigHelpers)
 
@@ -107,12 +113,12 @@ install(
         DESTINATION lib/cmake/flcl
 )
 
-install(TARGETS FLCL EXPORT flclTargets)
+install(TARGETS flcl EXPORT flclTargets)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod DESTINATION .)
 install(
     EXPORT flclTargets
     DESTINATION lib/cmake/flcl
-    NAMESPACE FLCL::)
+    NAMESPACE flcl::)
 
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ configure_package_config_file(
 
 write_basic_package_version_file(
     "${PROJECT_BINARY_DIR}/flclConfigVersion.cmake"
-    VERSION "${FLCL_VERSION}"
+    VERSION "${PROJECT_VERSION}"
     COMPATIBILITY SameMinorVersion
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,9 +66,11 @@ add_library(flcl
 )
 set_target_properties(flcl PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
 target_include_directories(flcl
+    PUBLIC
+        $<INSTALL_INTERFACE:"${CMAKE_INSTALL_INCLUDEDIR}">
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
-        $<INSTALL_INTERFACE:mod>
+        #$<INSTALL_INTERFACE:mod>
 )
 target_link_libraries(flcl
     INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
-project(flcl VERSION 0.4.0 LANGUAGES Fortran C CXX)
+set(FLCL_VERSION 0.4.0)
+project(flcl VERSION "${FLCL_VERSION}" LANGUAGES Fortran C CXX)
 
 set(default_build_type "RelWithDebInfo")
 set(BUILD_SHARED_LIBS OFF)
@@ -79,38 +79,41 @@ add_library(flcl::flcl ALIAS flcl)
 #installation section
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
+configure_package_config_file(
+    "cmake/flclConfig.cmake.in"
+    "${PROJECT_BINARY_DIR}/flclConfig.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake"
+)
+
 write_basic_package_version_file(
     "${PROJECT_BINARY_DIR}/flclConfigVersion.cmake"
+    VERSION "${FLCL_VERSION}"
     COMPATIBILITY SameMinorVersion
 )
 
-configure_package_config_file(
-    "${PROJECT_SOURCE_DIR}/cmake/flclConfig.cmake.in"
-    "${PROJECT_BINARY_DIR}/flclConfig.cmake"
-    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
-)
-
-#file(GLOB flcl_include_files "${CMAKE_CURRENT_SOURCE_DIR}/*.hxx")
-#install(FILES ${flcl_include_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-
+# install flcl cmake config files
 install(
     FILES
         "${PROJECT_BINARY_DIR}/flclConfigVersion.cmake"
         "${PROJECT_BINARY_DIR}/flclConfig.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
+install(TARGETS flcl EXPORT flclTargets)
+install(
+    EXPORT flclTargets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    NAMESPACE flcl::
+)
 
+# install flcl library and headers
 install(
     TARGETS flcl
-    EXPORT flclTargets
-    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
-install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod" DESTINATION .)
-install(
-    EXPORT flclTargets
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" 
-    NAMESPACE flcl::)
-file(GLOB flcl_mod_files "${CMAKE_CURRENT_BINARY_DIR}/mod/*.mod")
-install(FILES ${flcl_mod_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+# install flcl module files in include directory 
+install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 #unit testing section and toggle
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.17)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-set(FLCL_VERSION 0.4.0)
-project(flcl VERSION "${FLCL_VERSION}" LANGUAGES Fortran C CXX)
+project(flcl VERSION 0.4.0 LANGUAGES Fortran C CXX)
 
 set(default_build_type "RelWithDebInfo")
 set(BUILD_SHARED_LIBS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,24 +23,6 @@ include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
 
 include(CTest)
-# use, i.e. don't skip the full RPATH for the build tree
-#set(CMAKE_SKIP_BUILD_RPATH FALSE)
-
-# when building, don't use the install RPATH already
-# (but later on when installing)
-#set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-
-#set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
-# add the automatically determined parts of the RPATH
-# which point to directories outside the build tree to the install RPATH
-#set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-# the RPATH to be used when installing, but only if it's not a system directory
-#list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-#if("${isSystemDir}" STREQUAL "-1")
-#    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-#endif("${isSystemDir}" STREQUAL "-1")
 
 add_link_options(LINKER:--disable-new-dtags)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,7 @@
 cmake_minimum_required(VERSION 3.17)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
-set(FLCL_MAJOR_VERSION 0)
-set(FLCL_MINOR_VERSION 4)
-set(FLCL_PATCH_VERSION 0)
-set(FLCL_VERSION
-  ${FLCL_MAJOR_VERSION}.${FLCL_MINOR_VERSION}.${FLCL_PATCH_VERSION})
-
-project(flcl VERSION ${FLCLVERSION} LANGUAGES Fortran C CXX)
+project(flcl VERSION 0.4.0 LANGUAGES Fortran C CXX)
 
 set(default_build_type "RelWithDebInfo")
 set(BUILD_SHARED_LIBS OFF)
@@ -26,7 +20,7 @@ include(CTest)
 
 add_link_options(LINKER:--disable-new-dtags)
 
-
+#flcl-fortran library
 add_library(flcl-fortran
     OBJECT
         src/flcl-ndarray-f.f90
@@ -49,11 +43,17 @@ set_target_properties(
         Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
 )
 
+#flcl-cxx library
 add_library(flcl-cxx
     OBJECT
         src/flcl-cxx.cpp
         src/flcl-util-cxx.cpp
 )
+set(flcl-cxx-public-headers
+    ${PROJECT_SOURCE_DIR}/src/flcl-cxx.hpp
+    ${PROJECT_SOURCE_DIR}/src/flcl-util-cxx.h
+)
+set_target_properties(flcl-cxx PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
 target_link_libraries(flcl-cxx
     PRIVATE
         Kokkos::kokkos
@@ -64,6 +64,7 @@ add_library(flcl
         $<TARGET_OBJECTS:flcl-fortran>
         $<TARGET_OBJECTS:flcl-cxx>
 )
+set_target_properties(flcl PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
 target_include_directories(flcl
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
@@ -75,8 +76,9 @@ target_link_libraries(flcl
 )
 add_library(flcl::flcl ALIAS flcl)
 
+#installation section
 include(CMakePackageConfigHelpers)
-
+include(GNUInstallDirs)
 write_basic_package_version_file(
     "${PROJECT_BINARY_DIR}/flclConfigVersion.cmake"
     COMPATIBILITY SameMinorVersion
@@ -85,24 +87,32 @@ write_basic_package_version_file(
 configure_package_config_file(
     "${PROJECT_SOURCE_DIR}/cmake/flclConfig.cmake.in"
     "${PROJECT_BINARY_DIR}/flclConfig.cmake"
-    INSTALL_DESTINATION lib/cmake/flcl
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
+
+#file(GLOB flcl_include_files "${CMAKE_CURRENT_SOURCE_DIR}/*.hxx")
+#install(FILES ${flcl_include_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(
     FILES
         "${PROJECT_BINARY_DIR}/flclConfigVersion.cmake"
         "${PROJECT_BINARY_DIR}/flclConfig.cmake"
-        DESTINATION lib/cmake/flcl
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
-install(TARGETS flcl EXPORT flclTargets)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/mod DESTINATION .)
+install(
+    TARGETS flcl
+    EXPORT flclTargets
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} )
+install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod" DESTINATION .)
 install(
     EXPORT flclTargets
-    DESTINATION lib/cmake/flcl
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" 
     NAMESPACE flcl::)
+file(GLOB flcl_mod_files "${CMAKE_CURRENT_BINARY_DIR}/mod/*.mod")
+install(FILES ${flcl_mod_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-
+#unit testing section and toggle
 if(BUILD_TESTING)
   add_subdirectory(test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ include(CheckFortranCompilerFlag)
 include(CheckCXXCompilerFlag)
 include(CheckCCompilerFlag)
 
+include(GNUInstallDirs)
+
 include(CTest)
 
 add_link_options(LINKER:--disable-new-dtags)
@@ -34,7 +36,6 @@ target_include_directories(flcl-fortran
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
-        $<INSTALL_INTERFACE:mod>
 )
 set_target_properties(
     flcl-fortran
@@ -65,11 +66,9 @@ add_library(flcl
 )
 set_target_properties(flcl PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
 target_include_directories(flcl
-    PUBLIC
-        $<INSTALL_INTERFACE:"${CMAKE_INSTALL_INCLUDEDIR}">
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
-        #$<INSTALL_INTERFACE:mod>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(flcl
     INTERFACE
@@ -79,7 +78,6 @@ add_library(flcl::flcl ALIAS flcl)
 
 #installation section
 include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
 configure_package_config_file(
     "cmake/flclConfig.cmake.in"
     "${PROJECT_BINARY_DIR}/flclConfig.cmake"

--- a/examples/01-axpy-ndarray/CMakeLists.txt
+++ b/examples/01-axpy-ndarray/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_executable(example-axpy-ndarray axpy-ndarray-main.F90 axpy-ndarray-f.f90 axpy-ndarray-cxx.cc)
+set_target_properties(
+    example-axpy-ndarray
+    PROPERTIES
+        Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
+)
 target_include_directories(example-axpy-ndarray
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>

--- a/examples/01-axpy-ndarray/CMakeLists.txt
+++ b/examples/01-axpy-ndarray/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(example-axpy-ndarray
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src
 )
-target_link_libraries(example-axpy-ndarray ${PROJECT_LIBS} FLCL::flcl)
+target_link_libraries(example-axpy-ndarray ${PROJECT_LIBS} flcl::flcl)
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
     target_link_options(example-axpy-ndarray PRIVATE LINKER:-lxlf90_r)
 endif()

--- a/examples/02-axpy-dualview/CMakeLists.txt
+++ b/examples/02-axpy-dualview/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_executable(example-axpy-dualview axpy-dualview-main.F90 axpy-dualview-f.f90 axpy-dualview-cxx.cc)
+set_target_properties(
+    example-axpy-dualview
+    PROPERTIES
+        Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
+)
 target_include_directories(example-axpy-dualview
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>

--- a/examples/02-axpy-dualview/CMakeLists.txt
+++ b/examples/02-axpy-dualview/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(example-axpy-dualview
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src
 )
-target_link_libraries(example-axpy-dualview ${PROJECT_LIBS} FLCL::flcl)
+target_link_libraries(example-axpy-dualview ${PROJECT_LIBS} flcl::flcl)
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
     target_link_options(example-axpy-dualview PRIVATE LINKER:-lxlf90_r)
 endif()

--- a/examples/03-axpy-view/CMakeLists.txt
+++ b/examples/03-axpy-view/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_executable(example-axpy-view axpy-view-main.F90 axpy-view-f.f90 axpy-view-cxx.cc)
+set_target_properties(
+    example-axpy-view
+    PROPERTIES
+        Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
+)
 target_include_directories(example-axpy-view
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>

--- a/examples/03-axpy-view/CMakeLists.txt
+++ b/examples/03-axpy-view/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(example-axpy-view
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src
 )
-target_link_libraries(example-axpy-view ${PROJECT_LIBS} FLCL::flcl)
+target_link_libraries(example-axpy-view ${PROJECT_LIBS} flcl::flcl)
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
     target_link_options(example-axpy-view PRIVATE LINKER:-lxlf90_r)
 endif()

--- a/examples/04-complex-ndarray/CMakeLists.txt
+++ b/examples/04-complex-ndarray/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(example-complex-ndarray
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/../../src
 )
-target_link_libraries(example-complex-ndarray ${PROJECT_LIBS} FLCL::flcl)
+target_link_libraries(example-complex-ndarray ${PROJECT_LIBS} flcl::flcl)
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
     target_link_options(example-complex-ndarray PRIVATE LINKER:-lxlf90_r)
 endif()

--- a/examples/04-complex-ndarray/CMakeLists.txt
+++ b/examples/04-complex-ndarray/CMakeLists.txt
@@ -1,4 +1,9 @@
 add_executable(example-complex-ndarray complex-ndarray-main.F90 complex-ndarray-f.f90 complex-ndarray-cxx.cc)
+set_target_properties(
+    example-complex-ndarray
+    PROPERTIES
+        Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
+)
 target_include_directories(example-complex-ndarray
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(
         Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
 )
 target_link_libraries(flcl-testlib-fortran
-    FLCL::flcl
+    flcl::flcl
 )
 
 add_library(flcl-testlib-cxx
@@ -28,7 +28,7 @@ target_include_directories(flcl-testlib-cxx
         ${CMAKE_CURRENT_SOURCE_DIR}/../src
 )
 target_link_libraries(flcl-testlib-cxx
-    FLCL::flcl
+    flcl::flcl
 )
 
 add_library(flcl-testlib
@@ -42,7 +42,7 @@ target_include_directories(flcl-testlib
         $<INSTALL_INTERFACE:mod>
 )
 target_link_libraries(flcl-testlib
-    FLCL::flcl
+    flcl::flcl
 )
 
 #set_target_properties(flcl-testlib PROPERTIES INSTALL_RPATH ${RPATHS})
@@ -69,7 +69,7 @@ foreach(file ${files})
 	set_target_properties(${file_without_ext} PROPERTIES 
 						  BUILD_WITH_INSTALL_RPATH True
 						  INSTALL_RPATH "${RPATHS}")
- 	target_link_libraries(${file_without_ext} ${PROJECT_LIBS} FLCL::flcl flcl-testlib)
+ 	target_link_libraries(${file_without_ext} ${PROJECT_LIBS} flcl::flcl flcl-testlib)
     add_test(${file_without_ext} ${file_without_ext})
 	# set_target_properties(${file_without_ext} PROPERTIES LINKER_LANGUAGE Fortran) 
  	set_tests_properties(${file_without_ext}


### PR DESCRIPTION
- Adds C++ headers to include directory in installation
- Moves Fortran modules to include directory in installation
- Adds a module directory to example executables to suppress build warning messages
- Revs minor version in preparation for release