### PR TITLE
Fix pointer-level of char pointers passed from F to C in c_kokkos_print_configuration

### DIFF
--- a/src/flcl-util-cxx.cpp
+++ b/src/flcl-util-cxx.cpp
@@ -55,10 +55,10 @@ extern "C" {
     Kokkos::finalize();
   }
 
-  void c_kokkos_print_configuration(const char** prepend_name_in, const char** file_name_in) {
+  void c_kokkos_print_configuration(const char* prepend_name_in, const char* file_name_in) {
 
-    std::string prepend_name( *prepend_name_in );
-    std::string file_name( *file_name_in );
+    std::string prepend_name( prepend_name_in );
+    std::string file_name( file_name_in );
     std::string output_filename = prepend_name + file_name;
     std::ofstream kokkos_output_file ( output_filename );
     if ( kokkos_output_file.is_open()) {

--- a/src/flcl-util-cxx.h
+++ b/src/flcl-util-cxx.h
@@ -46,7 +46,7 @@ extern "C"
 void c_kokkos_initialize(int *argc, char **argv);
 void c_kokkos_initialize_without_args(void);
 void c_kokkos_finalize(void);
-void c_kokkos_print_configuration(const char** prepend_name_in, const char** file_name_in);
+void c_kokkos_print_configuration(const char* prepend_name_in, const char* file_name_in);
 
 #ifdef __cplusplus
 bool c_kokkos_is_initialized(void);


### PR DESCRIPTION
Incorrect pointer-level of several char pointers existed in c_kokkos_print_configuration which could lead to segfaulting when dereferenced as in the pre-fixed code.