### PR TITLE
Dualview support 4d-7d. Allocate/deallocate/unit tests/l,i32,i64,r32,…

### DIFF
--- a/src/flcl-cxx.cpp
+++ b/src/flcl-cxx.cpp
@@ -525,6 +525,240 @@ extern "C" {
     *A = (*v_A)->h_view.data();
   }
 
+// 4D flcl dualview allocation routines
+  void c_kokkos_allocate_dv_l_4d(bool** A, flcl::dualview_l_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_l_4d_t(c_label, e0t, e1t, e2t, e3t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i32_4d(int32_t** A, flcl::dualview_i32_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i32_4d_t(c_label, e0t, e1t, e2t, e3t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i64_4d(int64_t** A, flcl::dualview_i64_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i64_4d_t(c_label, e0t, e1t, e2t, e3t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r32_4d(float** A, flcl::dualview_r32_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r32_4d_t(c_label, e0t, e1t, e2t, e3t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r64_4d(double** A, flcl::dualview_r64_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r64_4d_t(c_label, e0t, e1t, e2t, e3t));
+    *A = (*v_A)->h_view.data();
+  }
+
+// 5D flcl dualview allocation routines
+  void c_kokkos_allocate_dv_l_5d(bool** A, flcl::dualview_l_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_l_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i32_5d(int32_t** A, flcl::dualview_i32_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i32_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i64_5d(int64_t** A, flcl::dualview_i64_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i64_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r32_5d(float** A, flcl::dualview_r32_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r32_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r64_5d(double** A, flcl::dualview_r64_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r64_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
+    *A = (*v_A)->h_view.data();
+  }
+
+// 6D flcl dualview allocation routines
+  void c_kokkos_allocate_dv_l_6d(bool** A, flcl::dualview_l_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_l_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i32_6d(int32_t** A, flcl::dualview_i32_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i32_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i64_6d(int64_t** A, flcl::dualview_i64_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i64_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r32_6d(float** A, flcl::dualview_r32_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r32_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r64_6d(double** A, flcl::dualview_r64_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r64_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
+    *A = (*v_A)->h_view.data();
+  }
+
+// 7D flcl dualview allocation routines
+  void c_kokkos_allocate_dv_l_7d(bool** A, flcl::dualview_l_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    const size_t e6t = std::max(*e6, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_l_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i32_7d(int32_t** A, flcl::dualview_i32_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    const size_t e6t = std::max(*e6, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i32_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_i64_7d(int64_t** A, flcl::dualview_i64_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    const size_t e6t = std::max(*e6, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_i64_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r32_7d(float** A, flcl::dualview_r32_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    const size_t e6t = std::max(*e6, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r32_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
+    *A = (*v_A)->h_view.data();
+  }
+
+  void c_kokkos_allocate_dv_r64_7d(double** A, flcl::dualview_r64_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
+    const size_t e0t = std::max(*e0, one);
+    const size_t e1t = std::max(*e1, one);
+    const size_t e2t = std::max(*e2, one);
+    const size_t e3t = std::max(*e3, one);
+    const size_t e4t = std::max(*e4, one);
+    const size_t e5t = std::max(*e5, one);
+    const size_t e6t = std::max(*e6, one);
+    std::string c_label( f_label );
+    *v_A = (new flcl::dualview_r64_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
+    *A = (*v_A)->h_view.data();
+  }
+
   // 1D flcl view deallocation routines
   void c_kokkos_deallocate_v_l_1d(flcl::view_l_1d_t** v_A) {
     delete(*v_A);
@@ -732,6 +966,90 @@ extern "C" {
   }
 
   void c_kokkos_deallocate_dv_r64_3d(flcl::dualview_r64_3d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  // 4D flcl dualview deallocation routines
+  void c_kokkos_deallocate_dv_l_4d(flcl::dualview_l_4d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i32_4d(flcl::dualview_i32_4d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i64_4d(flcl::dualview_i64_4d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r32_4d(flcl::dualview_r32_4d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r64_4d(flcl::dualview_r64_4d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  // 5D flcl dualview deallocation routines
+  void c_kokkos_deallocate_dv_l_5d(flcl::dualview_l_5d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i32_5d(flcl::dualview_i32_5d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i64_5d(flcl::dualview_i64_5d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r32_5d(flcl::dualview_r32_5d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r64_5d(flcl::dualview_r64_5d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  // 6D flcl dualview deallocation routines
+  void c_kokkos_deallocate_dv_l_6d(flcl::dualview_l_6d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i32_6d(flcl::dualview_i32_6d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i64_6d(flcl::dualview_i64_6d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r32_6d(flcl::dualview_r32_6d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r64_6d(flcl::dualview_r64_6d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  // 7D flcl dualview deallocation routines
+  void c_kokkos_deallocate_dv_l_7d(flcl::dualview_l_7d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i32_7d(flcl::dualview_i32_7d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_i64_7d(flcl::dualview_i64_7d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r32_7d(flcl::dualview_r32_7d_t** v_A) {
+    delete(*v_A);    
+  }
+
+  void c_kokkos_deallocate_dv_r64_7d(flcl::dualview_r64_7d_t** v_A) {
     delete(*v_A);    
   }
 

--- a/src/flcl-cxx.hpp
+++ b/src/flcl-cxx.hpp
@@ -130,26 +130,54 @@ namespace flcl {
   typedef Kokkos::View<double*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>      view_r64_7d_t;
   
   // 1D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool*,Kokkos::LayoutLeft>                        dualview_l_1d_t;
-  typedef Kokkos::DualView<int32_t*,Kokkos::LayoutLeft>                     dualview_i32_1d_t;
-  typedef Kokkos::DualView<int64_t*,Kokkos::LayoutLeft>                     dualview_i64_1d_t;
-  typedef Kokkos::DualView<float*,Kokkos::LayoutLeft>                       dualview_r32_1d_t;
-  typedef Kokkos::DualView<double*,Kokkos::LayoutLeft>                      dualview_r64_1d_t;
+  typedef Kokkos::DualView<bool*,Kokkos::LayoutLeft>                                dualview_l_1d_t;
+  typedef Kokkos::DualView<int32_t*,Kokkos::LayoutLeft>                             dualview_i32_1d_t;
+  typedef Kokkos::DualView<int64_t*,Kokkos::LayoutLeft>                             dualview_i64_1d_t;
+  typedef Kokkos::DualView<float*,Kokkos::LayoutLeft>                               dualview_r32_1d_t;
+  typedef Kokkos::DualView<double*,Kokkos::LayoutLeft>                              dualview_r64_1d_t;
 
   // 2D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool**,Kokkos::LayoutLeft>     dualview_l_2d_t;
-  typedef Kokkos::DualView<int32_t**,Kokkos::LayoutLeft>  dualview_i32_2d_t;
-  typedef Kokkos::DualView<int64_t**,Kokkos::LayoutLeft>  dualview_i64_2d_t;
-  typedef Kokkos::DualView<float**,Kokkos::LayoutLeft>    dualview_r32_2d_t;
-  typedef Kokkos::DualView<double**,Kokkos::LayoutLeft>   dualview_r64_2d_t;
+  typedef Kokkos::DualView<bool**,Kokkos::LayoutLeft>                               dualview_l_2d_t;
+  typedef Kokkos::DualView<int32_t**,Kokkos::LayoutLeft>                            dualview_i32_2d_t;
+  typedef Kokkos::DualView<int64_t**,Kokkos::LayoutLeft>                            dualview_i64_2d_t;
+  typedef Kokkos::DualView<float**,Kokkos::LayoutLeft>                              dualview_r32_2d_t;
+  typedef Kokkos::DualView<double**,Kokkos::LayoutLeft>                             dualview_r64_2d_t;
 
   // 3D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool***,Kokkos::LayoutLeft>    dualview_l_3d_t;
-  typedef Kokkos::DualView<int32_t***,Kokkos::LayoutLeft> dualview_i32_3d_t;
-  typedef Kokkos::DualView<int64_t***,Kokkos::LayoutLeft> dualview_i64_3d_t;
-  typedef Kokkos::DualView<float***,Kokkos::LayoutLeft>   dualview_r32_3d_t;
-  typedef Kokkos::DualView<double***,Kokkos::LayoutLeft>  dualview_r64_3d_t;
-    
+  typedef Kokkos::DualView<bool***,Kokkos::LayoutLeft>                              dualview_l_3d_t;
+  typedef Kokkos::DualView<int32_t***,Kokkos::LayoutLeft>                           dualview_i32_3d_t;
+  typedef Kokkos::DualView<int64_t***,Kokkos::LayoutLeft>                           dualview_i64_3d_t;
+  typedef Kokkos::DualView<float***,Kokkos::LayoutLeft>                             dualview_r32_3d_t;
+  typedef Kokkos::DualView<double***,Kokkos::LayoutLeft>                            dualview_r64_3d_t;
+
+  // 4D fortran-compatible dualview types
+  typedef Kokkos::DualView<bool****,Kokkos::LayoutLeft>                             dualview_l_4d_t;
+  typedef Kokkos::DualView<int32_t****,Kokkos::LayoutLeft>                          dualview_i32_4d_t;
+  typedef Kokkos::DualView<int64_t****,Kokkos::LayoutLeft>                          dualview_i64_4d_t;
+  typedef Kokkos::DualView<float****,Kokkos::LayoutLeft>                            dualview_r32_4d_t;
+  typedef Kokkos::DualView<double****,Kokkos::LayoutLeft>                           dualview_r64_4d_t;
+
+  // 5D fortran-compatible dualview types
+  typedef Kokkos::DualView<bool*****,Kokkos::LayoutLeft>                            dualview_l_5d_t;
+  typedef Kokkos::DualView<int32_t*****,Kokkos::LayoutLeft>                         dualview_i32_5d_t;
+  typedef Kokkos::DualView<int64_t*****,Kokkos::LayoutLeft>                         dualview_i64_5d_t;
+  typedef Kokkos::DualView<float*****,Kokkos::LayoutLeft>                           dualview_r32_5d_t;
+  typedef Kokkos::DualView<double*****,Kokkos::LayoutLeft>                          dualview_r64_5d_t;
+
+  // 6D fortran-compatible dualview types
+  typedef Kokkos::DualView<bool******,Kokkos::LayoutLeft>                           dualview_l_6d_t;
+  typedef Kokkos::DualView<int32_t******,Kokkos::LayoutLeft>                        dualview_i32_6d_t;
+  typedef Kokkos::DualView<int64_t******,Kokkos::LayoutLeft>                        dualview_i64_6d_t;
+  typedef Kokkos::DualView<float******,Kokkos::LayoutLeft>                          dualview_r32_6d_t;
+  typedef Kokkos::DualView<double******,Kokkos::LayoutLeft>                         dualview_r64_6d_t;
+
+  // 7D fortran-compatible dualview types
+  typedef Kokkos::DualView<bool*******,Kokkos::LayoutLeft>                          dualview_l_7d_t;
+  typedef Kokkos::DualView<int32_t*******,Kokkos::LayoutLeft>                       dualview_i32_7d_t;
+  typedef Kokkos::DualView<int64_t*******,Kokkos::LayoutLeft>                       dualview_i64_7d_t;
+  typedef Kokkos::DualView<float*******,Kokkos::LayoutLeft>                         dualview_r32_7d_t;
+  typedef Kokkos::DualView<double*******,Kokkos::LayoutLeft>                        dualview_r64_7d_t;
+
   template <typename DataType>
   Kokkos::View<DataType, Kokkos::LayoutStride, flcl::HostMemorySpace>
   view_from_ndarray(flcl_ndarray_t const &ndarray) {

--- a/src/flcl-dualview-f.f90
+++ b/src/flcl-dualview-f.f90
@@ -194,110 +194,150 @@ module flcl_dualview_mod
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! 4D Kokkos DualView types
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  type, bind(c) :: dualview_l_4d_t
+  type dualview_l_4d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_l_4d_t
   end type dualview_l_4d_t
 
-  type, bind(c) :: dualview_i32_4d_t
+  type dualview_i32_4d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i32_4d_t
   end type dualview_i32_4d_t
 
-  type, bind(c) :: dualview_i64_4d_t
+  type dualview_i64_4d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i64_4d_t
   end type dualview_i64_4d_t
 
-  type, bind(c) :: dualview_r32_4d_t
+  type dualview_r32_4d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r32_4d_t
   end type dualview_r32_4d_t
 
-  type, bind(c) :: dualview_r64_4d_t
+  type dualview_r64_4d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r64_4d_t
   end type dualview_r64_4d_t
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! 5D Kokkos DualView types
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  type, bind(c) :: dualview_l_5d_t
+  type dualview_l_5d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_l_5d_t
   end type dualview_l_5d_t
 
-  type, bind(c) :: dualview_i32_5d_t
+  type dualview_i32_5d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i32_5d_t
   end type dualview_i32_5d_t
 
-  type, bind(c) :: dualview_i64_5d_t
+  type dualview_i64_5d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i64_5d_t
   end type dualview_i64_5d_t
 
-  type, bind(c) :: dualview_r32_5d_t
+  type dualview_r32_5d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r32_5d_t
   end type dualview_r32_5d_t
 
-  type, bind(c) :: dualview_r64_5d_t
+  type dualview_r64_5d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r64_5d_t
   end type dualview_r64_5d_t
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! 6D Kokkos DualView types
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  type, bind(c) :: dualview_l_6d_t
+  type dualview_l_6d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_l_6d_t
   end type dualview_l_6d_t
 
-  type, bind(c) :: dualview_i32_6d_t
+  type dualview_i32_6d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i32_6d_t
   end type dualview_i32_6d_t
 
-  type, bind(c) :: dualview_i64_6d_t
+  type dualview_i64_6d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i64_6d_t
   end type dualview_i64_6d_t
 
-  type, bind(c) :: dualview_r32_6d_t
+  type dualview_r32_6d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r32_6d_t
   end type dualview_r32_6d_t
 
-  type, bind(c) :: dualview_r64_6d_t
+  type dualview_r64_6d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r64_6d_t
   end type dualview_r64_6d_t
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! 7D Kokkos DualView types
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  type, bind(c) :: dualview_l_7d_t
+  type dualview_l_7d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_l_7d_t
   end type dualview_l_7d_t
 
-  type, bind(c) :: dualview_i32_7d_t
+  type dualview_i32_7d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i32_7d_t
   end type dualview_i32_7d_t
 
-  type, bind(c) :: dualview_i64_7d_t
+  type dualview_i64_7d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_i64_7d_t
   end type dualview_i64_7d_t
 
-  type, bind(c) :: dualview_r32_7d_t
+  type dualview_r32_7d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r32_7d_t
   end type dualview_r32_7d_t
 
-  type, bind(c) :: dualview_r64_7d_t
+  type dualview_r64_7d_t
     private
       type(c_ptr) :: handle
+    contains
+      procedure :: ptr => view_ptr_dualview_r64_7d_t
   end type dualview_r64_7d_t
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! kokkos_allocate_dualview interface
@@ -323,6 +363,34 @@ module flcl_dualview_mod
     module procedure kokkos_allocate_dv_i64_3d
     module procedure kokkos_allocate_dv_r32_3d
     module procedure kokkos_allocate_dv_r64_3d
+
+    ! 4D specializations
+    module procedure kokkos_allocate_dv_l_4d
+    module procedure kokkos_allocate_dv_i32_4d
+    module procedure kokkos_allocate_dv_i64_4d
+    module procedure kokkos_allocate_dv_r32_4d
+    module procedure kokkos_allocate_dv_r64_4d
+
+    ! 5D specializations  
+    module procedure kokkos_allocate_dv_l_5d
+    module procedure kokkos_allocate_dv_i32_5d
+    module procedure kokkos_allocate_dv_i64_5d
+    module procedure kokkos_allocate_dv_r32_5d
+    module procedure kokkos_allocate_dv_r64_5d
+
+    ! 6D specializations
+    module procedure kokkos_allocate_dv_l_6d
+    module procedure kokkos_allocate_dv_i32_6d
+    module procedure kokkos_allocate_dv_i64_6d
+    module procedure kokkos_allocate_dv_r32_6d
+    module procedure kokkos_allocate_dv_r64_6d
+
+    ! 7D specializations
+    module procedure kokkos_allocate_dv_l_7d
+    module procedure kokkos_allocate_dv_i32_7d
+    module procedure kokkos_allocate_dv_i64_7d
+    module procedure kokkos_allocate_dv_r32_7d
+    module procedure kokkos_allocate_dv_r64_7d
   end interface kokkos_allocate_dualview
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! kokkos_deallocate_dualview interface
@@ -348,6 +416,34 @@ module flcl_dualview_mod
     module procedure kokkos_deallocate_dv_i64_3d
     module procedure kokkos_deallocate_dv_r32_3d
     module procedure kokkos_deallocate_dv_r64_3d
+
+    ! 4D specializations
+    module procedure kokkos_deallocate_dv_l_4d  
+    module procedure kokkos_deallocate_dv_i32_4d
+    module procedure kokkos_deallocate_dv_i64_4d
+    module procedure kokkos_deallocate_dv_r32_4d
+    module procedure kokkos_deallocate_dv_r64_4d
+
+    ! 5D specializations
+    module procedure kokkos_deallocate_dv_l_5d  
+    module procedure kokkos_deallocate_dv_i32_5d
+    module procedure kokkos_deallocate_dv_i64_5d
+    module procedure kokkos_deallocate_dv_r32_5d
+    module procedure kokkos_deallocate_dv_r64_5d
+
+    ! 6D specializations
+    module procedure kokkos_deallocate_dv_l_6d  
+    module procedure kokkos_deallocate_dv_i32_6d
+    module procedure kokkos_deallocate_dv_i64_6d
+    module procedure kokkos_deallocate_dv_r32_6d
+    module procedure kokkos_deallocate_dv_r64_6d
+
+    ! 7D specializations
+    module procedure kokkos_deallocate_dv_l_7d  
+    module procedure kokkos_deallocate_dv_i32_7d
+    module procedure kokkos_deallocate_dv_i64_7d
+    module procedure kokkos_deallocate_dv_r32_7d
+    module procedure kokkos_deallocate_dv_r64_7d
   end interface kokkos_deallocate_dualview
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! kokkos_allocate_dualview 1D interfaces
@@ -551,6 +647,344 @@ module flcl_dualview_mod
     end subroutine f_kokkos_allocate_dv_r64_3d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_allocate_dualview 4D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_allocate_dv_l_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
+      & bind (c, name='c_kokkos_allocate_dv_l_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+    end subroutine f_kokkos_allocate_dv_l_4d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_i32_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
+      & bind (c, name='c_kokkos_allocate_dv_i32_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+    end subroutine f_kokkos_allocate_dv_i32_4d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_i64_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
+      & bind (c, name='c_kokkos_allocate_dv_i64_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+    end subroutine f_kokkos_allocate_dv_i64_4d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_r32_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
+      & bind (c, name='c_kokkos_allocate_dv_r32_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+    end subroutine f_kokkos_allocate_dv_r32_4d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_r64_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
+      & bind (c, name='c_kokkos_allocate_dv_r64_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+    end subroutine f_kokkos_allocate_dv_r64_4d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_allocate_dualview 5D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_allocate_dv_l_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
+      & bind (c, name='c_kokkos_allocate_dv_l_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+    end subroutine f_kokkos_allocate_dv_l_5d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_i32_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
+      & bind (c, name='c_kokkos_allocate_dv_i32_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+    end subroutine f_kokkos_allocate_dv_i32_5d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_i64_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
+      & bind (c, name='c_kokkos_allocate_dv_i64_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+    end subroutine f_kokkos_allocate_dv_i64_5d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_r32_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
+      & bind (c, name='c_kokkos_allocate_dv_r32_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+    end subroutine f_kokkos_allocate_dv_r32_5d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_r64_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
+      & bind (c, name='c_kokkos_allocate_dv_r64_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+    end subroutine f_kokkos_allocate_dv_r64_5d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_allocate_dualview 6D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_allocate_dv_l_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
+      & bind (c, name='c_kokkos_allocate_dv_l_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+    end subroutine f_kokkos_allocate_dv_l_6d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_i32_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
+      & bind (c, name='c_kokkos_allocate_dv_i32_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+    end subroutine f_kokkos_allocate_dv_i32_6d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_i64_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
+      & bind (c, name='c_kokkos_allocate_dv_i64_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+    end subroutine f_kokkos_allocate_dv_i64_6d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_r32_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
+      & bind (c, name='c_kokkos_allocate_dv_r32_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+    end subroutine f_kokkos_allocate_dv_r32_6d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_r64_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
+      & bind (c, name='c_kokkos_allocate_dv_r64_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+    end subroutine f_kokkos_allocate_dv_r64_6d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_allocate_dualview 7D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_allocate_dv_l_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
+      & bind (c, name='c_kokkos_allocate_dv_l_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+    end subroutine f_kokkos_allocate_dv_l_7d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_i32_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
+      & bind (c, name='c_kokkos_allocate_dv_i32_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+    end subroutine f_kokkos_allocate_dv_i32_7d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_i64_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
+      & bind (c, name='c_kokkos_allocate_dv_i64_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+    end subroutine f_kokkos_allocate_dv_i64_7d
+  end interface
+
+  interface 
+    subroutine f_kokkos_allocate_dv_r32_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
+      & bind (c, name='c_kokkos_allocate_dv_r32_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+    end subroutine f_kokkos_allocate_dv_r32_7d
+  end interface
+  
+  interface 
+    subroutine f_kokkos_allocate_dv_r64_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
+      & bind (c, name='c_kokkos_allocate_dv_r64_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: c_A
+      type(c_ptr), intent(out) :: v_A
+      character(kind=c_char), intent(in) :: n_A(*)
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+    end subroutine f_kokkos_allocate_dv_r64_7d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! kokkos_deallocate_dualview 1D interfaces
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   interface 
@@ -645,7 +1079,7 @@ module flcl_dualview_mod
     end subroutine f_kokkos_deallocate_dv_r64_2d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!!! kokkos_deallocate_dualview 1D interfaces
+!!! kokkos_deallocate_dualview 3D interfaces
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   interface 
     subroutine f_kokkos_deallocate_dv_l_3d(v_A) &
@@ -690,6 +1124,194 @@ module flcl_dualview_mod
       implicit none
       type(c_ptr), intent(out) :: v_A
     end subroutine f_kokkos_deallocate_dv_r64_3d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_deallocate_dualview 4D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_deallocate_dv_l_4d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_l_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_l_4d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i32_4d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i32_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i32_4d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i64_4d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i64_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i64_4d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r32_4d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r32_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r32_4d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r64_4d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r64_4d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r64_4d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_deallocate_dualview 5D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_deallocate_dv_l_5d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_l_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_l_5d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i32_5d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i32_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i32_5d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i64_5d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i64_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i64_5d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r32_5d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r32_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r32_5d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r64_5d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r64_5d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r64_5d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_deallocate_dualview 6D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_deallocate_dv_l_6d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_l_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_l_6d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i32_6d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i32_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i32_6d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i64_6d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i64_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i64_6d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r32_6d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r32_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r32_6d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r64_6d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r64_6d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r64_6d
+  end interface
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos_deallocate_dualview 7D interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  interface 
+    subroutine f_kokkos_deallocate_dv_l_7d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_l_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_l_7d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i32_7d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i32_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i32_7d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_i64_7d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_i64_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_i64_7d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r32_7d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r32_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r32_7d
+  end interface
+
+  interface 
+    subroutine f_kokkos_deallocate_dv_r64_7d(v_A) &
+      & bind (c, name='c_kokkos_deallocate_dv_r64_7d')
+      use, intrinsic :: iso_c_binding
+      implicit none
+      type(c_ptr), intent(out) :: v_A
+    end subroutine f_kokkos_deallocate_dv_r64_7d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   contains
@@ -972,6 +1594,444 @@ module flcl_dualview_mod
       call c_f_pointer(c_A, A, shape=[e0,e1,e2])
     end subroutine kokkos_allocate_dv_r64_3d
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos allocate dualview 4D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    subroutine kokkos_allocate_dv_l_4d(A, v_A, n_A, e0, e1, e2, e3)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      logical(c_bool), pointer, dimension(:,:,:,:), intent(inout) :: A
+      type(dualview_l_4d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_l_4d(c_A, v_A%handle, f_label, e0, e1, e2, e3)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3])
+    end subroutine kokkos_allocate_dv_l_4d
+  
+    subroutine kokkos_allocate_dv_i32_4d(A, v_A, n_A, e0, e1, e2, e3)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      type(dualview_i32_4d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i32_4d(c_A, v_A%handle, f_label, e0, e1, e2, e3)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3])
+    end subroutine kokkos_allocate_dv_i32_4d
+  
+    subroutine kokkos_allocate_dv_i64_4d(A, v_A, n_A, e0, e1, e2, e3)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      type(dualview_i64_4d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i64_4d(c_A, v_A%handle, f_label, e0, e1, e2, e3)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3])
+    end subroutine kokkos_allocate_dv_i64_4d
+  
+    subroutine kokkos_allocate_dv_r32_4d(A, v_A, n_A, e0, e1, e2, e3)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      type(dualview_r32_4d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+  
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r32_4d(c_A, v_A%handle, f_label, e0, e1, e2, e3)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3])
+    end subroutine kokkos_allocate_dv_r32_4d
+  
+    subroutine kokkos_allocate_dv_r64_4d(A, v_A, n_A, e0, e1, e2, e3)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      type(dualview_r64_4d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      type(c_ptr) :: c_A
+
+      character(len=:, kind=c_char), allocatable, target :: f_label
+
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r64_4d(c_A, v_A%handle, f_label, e0, e1, e2, e3)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3])
+    end subroutine kokkos_allocate_dv_r64_4d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos allocate dualview 5D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    subroutine kokkos_allocate_dv_l_5d(A, v_A, n_A, e0, e1, e2, e3, e4)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      logical(c_bool), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      type(dualview_l_5d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_l_5d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4])
+    end subroutine kokkos_allocate_dv_l_5d
+  
+    subroutine kokkos_allocate_dv_i32_5d(A, v_A, n_A, e0, e1, e2, e3, e4)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      type(dualview_i32_5d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i32_5d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4])
+    end subroutine kokkos_allocate_dv_i32_5d
+  
+    subroutine kokkos_allocate_dv_i64_5d(A, v_A, n_A, e0, e1, e2, e3, e4)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      type(dualview_i64_5d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i64_5d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4])
+    end subroutine kokkos_allocate_dv_i64_5d
+  
+    subroutine kokkos_allocate_dv_r32_5d(A, v_A, n_A, e0, e1, e2, e3, e4)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      type(dualview_r32_5d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+  
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r32_5d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4])
+    end subroutine kokkos_allocate_dv_r32_5d
+  
+    subroutine kokkos_allocate_dv_r64_5d(A, v_A, n_A, e0, e1, e2, e3, e4)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      type(dualview_r64_5d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      type(c_ptr) :: c_A
+
+      character(len=:, kind=c_char), allocatable, target :: f_label
+
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r64_5d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4])
+    end subroutine kokkos_allocate_dv_r64_5d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos allocate dualview 6D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    subroutine kokkos_allocate_dv_l_6d(A, v_A, n_A, e0, e1, e2, e3, e4, e5)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      logical(c_bool), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_l_6d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_l_6d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5])
+    end subroutine kokkos_allocate_dv_l_6d
+  
+    subroutine kokkos_allocate_dv_i32_6d(A, v_A, n_A, e0, e1, e2, e3, e4, e5)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_i32_6d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i32_6d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5])
+    end subroutine kokkos_allocate_dv_i32_6d
+  
+    subroutine kokkos_allocate_dv_i64_6d(A, v_A, n_A, e0, e1, e2, e3, e4, e5)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_i64_6d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i64_6d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5])
+    end subroutine kokkos_allocate_dv_i64_6d
+  
+    subroutine kokkos_allocate_dv_r32_6d(A, v_A, n_A, e0, e1, e2, e3, e4, e5)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_r32_6d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+  
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r32_6d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5])
+    end subroutine kokkos_allocate_dv_r32_6d
+  
+    subroutine kokkos_allocate_dv_r64_6d(A, v_A, n_A, e0, e1, e2, e3, e4, e5)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_r64_6d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      type(c_ptr) :: c_A
+
+      character(len=:, kind=c_char), allocatable, target :: f_label
+
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r64_6d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5])
+    end subroutine kokkos_allocate_dv_r64_6d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos allocate dualview 7D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    subroutine kokkos_allocate_dv_l_7d(A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      logical(c_bool), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_l_7d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_l_7d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5, e6)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5,e6])
+    end subroutine kokkos_allocate_dv_l_7d
+  
+    subroutine kokkos_allocate_dv_i32_7d(A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_i32_7d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i32_7d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5, e6)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5,e6])
+    end subroutine kokkos_allocate_dv_i32_7d
+  
+    subroutine kokkos_allocate_dv_i64_7d(A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      integer(INT64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_i64_7d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+      
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_i64_7d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5, e6)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5,e6])
+    end subroutine kokkos_allocate_dv_i64_7d
+  
+    subroutine kokkos_allocate_dv_r32_7d(A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_r32_7d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+      type(c_ptr) :: c_A
+  
+      character(len=:, kind=c_char), allocatable, target :: f_label
+  
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r32_7d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5, e6)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5,e6])
+    end subroutine kokkos_allocate_dv_r32_7d
+  
+    subroutine kokkos_allocate_dv_r64_7d(A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6)
+      use, intrinsic :: iso_c_binding
+      use flcl_util_strings_mod, only: char_add_null
+      implicit none
+      real(REAL64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      type(dualview_r64_7d_t), intent(out) :: v_A
+      character(len=*), intent(in) :: n_A
+      integer(c_size_t), intent(in) :: e0
+      integer(c_size_t), intent(in) :: e1
+      integer(c_size_t), intent(in) :: e2
+      integer(c_size_t), intent(in) :: e3
+      integer(c_size_t), intent(in) :: e4
+      integer(c_size_t), intent(in) :: e5
+      integer(c_size_t), intent(in) :: e6
+      type(c_ptr) :: c_A
+
+      character(len=:, kind=c_char), allocatable, target :: f_label
+
+      call char_add_null( n_A, f_label )
+      call f_kokkos_allocate_dv_r64_7d(c_A, v_A%handle, f_label, e0, e1, e2, e3, e4, e5, e6)
+      call c_f_pointer(c_A, A, shape=[e0,e1,e2,e3,e4,e5,e6])
+    end subroutine kokkos_allocate_dv_r64_7d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! kokkos deallocate dualview 1D implementations
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   subroutine kokkos_deallocate_dv_l_1d(A, v_A )
@@ -1160,6 +2220,254 @@ module flcl_dualview_mod
 
   end subroutine kokkos_deallocate_dv_r64_3d
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos deallocate dualview 4D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  subroutine kokkos_deallocate_dv_l_4d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    logical(c_bool), pointer, dimension(:,:,:,:), intent(inout) :: A
+    type(dualview_l_4d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_l_4d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_l_4d
+
+  subroutine kokkos_deallocate_dv_i32_4d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT32), pointer, dimension(:,:,:,:), intent(inout) :: A
+    type(dualview_i32_4d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i32_4d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i32_4d
+
+  subroutine kokkos_deallocate_dv_i64_4d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT64), pointer, dimension(:,:,:,:), intent(inout) :: A
+    type(dualview_i64_4d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i64_4d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i64_4d
+
+  subroutine kokkos_deallocate_dv_r32_4d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL32), pointer, dimension(:,:,:,:), intent(inout) :: A
+    type(dualview_r32_4d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r32_4d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r32_4d
+
+  subroutine kokkos_deallocate_dv_r64_4d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL64), pointer, dimension(:,:,:,:), intent(inout) :: A
+    type(dualview_r64_4d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r64_4d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r64_4d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos deallocate dualview 5D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  subroutine kokkos_deallocate_dv_l_5d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    logical(c_bool), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    type(dualview_l_5d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_l_5d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_l_5d
+
+  subroutine kokkos_deallocate_dv_i32_5d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    type(dualview_i32_5d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i32_5d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i32_5d
+
+  subroutine kokkos_deallocate_dv_i64_5d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    type(dualview_i64_5d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i64_5d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i64_5d
+
+  subroutine kokkos_deallocate_dv_r32_5d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    type(dualview_r32_5d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r32_5d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r32_5d
+
+  subroutine kokkos_deallocate_dv_r64_5d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    type(dualview_r64_5d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r64_5d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r64_5d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos deallocate dualview 6D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  subroutine kokkos_deallocate_dv_l_6d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    logical(c_bool), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_l_6d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_l_6d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_l_6d
+
+  subroutine kokkos_deallocate_dv_i32_6d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_i32_6d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i32_6d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i32_6d
+
+  subroutine kokkos_deallocate_dv_i64_6d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_i64_6d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i64_6d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i64_6d
+
+  subroutine kokkos_deallocate_dv_r32_6d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_r32_6d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r32_6d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r32_6d
+
+  subroutine kokkos_deallocate_dv_r64_6d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_r64_6d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r64_6d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r64_6d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! kokkos deallocate dualview 7D implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  subroutine kokkos_deallocate_dv_l_7d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    logical(c_bool), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_l_7d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_l_7d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_l_7d
+
+  subroutine kokkos_deallocate_dv_i32_7d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_i32_7d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i32_7d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i32_7d
+
+  subroutine kokkos_deallocate_dv_i64_7d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    integer(INT64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_i64_7d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_i64_7d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_i64_7d
+
+  subroutine kokkos_deallocate_dv_r32_7d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_r32_7d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r32_7d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r32_7d
+
+  subroutine kokkos_deallocate_dv_r64_7d(A, v_A )
+    use, intrinsic :: iso_c_binding
+    implicit none
+    real(REAL64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    type(dualview_r64_7d_t), intent(inout) :: v_A
+
+    A => NULL()
+    call f_kokkos_deallocate_dv_r64_7d(v_A%handle)
+    v_A%handle = c_null_ptr
+
+  end subroutine kokkos_deallocate_dv_r64_7d
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! view_ptr_dualview 1d implementations
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   type(c_ptr) function view_ptr_dualview_l_1d_t( self ) result( result_ptr )
@@ -1194,67 +2502,195 @@ module flcl_dualview_mod
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! view_ptr_dualview 2d implementations
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-type(c_ptr) function view_ptr_dualview_l_2d_t( self ) result( result_ptr )
-  implicit none
-  class( dualview_l_2d_t ), intent(in) :: self
-  result_ptr = self%handle
-end function view_ptr_dualview_l_2d_t
+  type(c_ptr) function view_ptr_dualview_l_2d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_l_2d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_l_2d_t
 
-type(c_ptr) function view_ptr_dualview_i32_2d_t( self ) result( result_ptr )
-  implicit none
-  class( dualview_i32_2d_t ), intent(in) :: self
-  result_ptr = self%handle
-end function view_ptr_dualview_i32_2d_t
+  type(c_ptr) function view_ptr_dualview_i32_2d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i32_2d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i32_2d_t
 
-type(c_ptr) function view_ptr_dualview_i64_2d_t( self ) result( result_ptr )
-implicit none
-class( dualview_i64_2d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_i64_2d_t
+  type(c_ptr) function view_ptr_dualview_i64_2d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i64_2d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i64_2d_t
 
-type(c_ptr) function view_ptr_dualview_r32_2d_t( self ) result( result_ptr )
-implicit none
-class( dualview_r32_2d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_r32_2d_t
+  type(c_ptr) function view_ptr_dualview_r32_2d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r32_2d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r32_2d_t
 
-type(c_ptr) function view_ptr_dualview_r64_2d_t( self ) result( result_ptr )
-implicit none
-class( dualview_r64_2d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_r64_2d_t
+  type(c_ptr) function view_ptr_dualview_r64_2d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r64_2d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r64_2d_t
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! view_ptr_dualview 3d implementations
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-type(c_ptr) function view_ptr_dualview_l_3d_t( self ) result( result_ptr )
-implicit none
-class( dualview_l_3d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_l_3d_t
+  type(c_ptr) function view_ptr_dualview_l_3d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_l_3d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_l_3d_t
 
-type(c_ptr) function view_ptr_dualview_i32_3d_t( self ) result( result_ptr )
-implicit none
-class( dualview_i32_3d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_i32_3d_t
+  type(c_ptr) function view_ptr_dualview_i32_3d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i32_3d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i32_3d_t
 
-type(c_ptr) function view_ptr_dualview_i64_3d_t( self ) result( result_ptr )
-implicit none
-class( dualview_i64_3d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_i64_3d_t
+  type(c_ptr) function view_ptr_dualview_i64_3d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i64_3d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i64_3d_t
 
-type(c_ptr) function view_ptr_dualview_r32_3d_t( self ) result( result_ptr )
-implicit none
-class( dualview_r32_3d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_r32_3d_t
+  type(c_ptr) function view_ptr_dualview_r32_3d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r32_3d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r32_3d_t
 
-type(c_ptr) function view_ptr_dualview_r64_3d_t( self ) result( result_ptr )
-implicit none
-class( dualview_r64_3d_t ), intent(in) :: self
-result_ptr = self%handle
-end function view_ptr_dualview_r64_3d_t
+  type(c_ptr) function view_ptr_dualview_r64_3d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r64_3d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r64_3d_t
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! view_ptr_dualview 4d implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  type(c_ptr) function view_ptr_dualview_l_4d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_l_4d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_l_4d_t
+
+  type(c_ptr) function view_ptr_dualview_i32_4d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i32_4d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i32_4d_t
+
+  type(c_ptr) function view_ptr_dualview_i64_4d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i64_4d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i64_4d_t
+
+  type(c_ptr) function view_ptr_dualview_r32_4d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r32_4d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r32_4d_t
+
+  type(c_ptr) function view_ptr_dualview_r64_4d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r64_4d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r64_4d_t
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! view_ptr_dualview 5d implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  type(c_ptr) function view_ptr_dualview_l_5d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_l_5d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_l_5d_t
+
+  type(c_ptr) function view_ptr_dualview_i32_5d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i32_5d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i32_5d_t
+
+  type(c_ptr) function view_ptr_dualview_i64_5d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i64_5d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i64_5d_t
+
+  type(c_ptr) function view_ptr_dualview_r32_5d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r32_5d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r32_5d_t
+
+  type(c_ptr) function view_ptr_dualview_r64_5d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r64_5d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r64_5d_t
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! view_ptr_dualview 6d implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  type(c_ptr) function view_ptr_dualview_l_6d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_l_6d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_l_6d_t
+
+  type(c_ptr) function view_ptr_dualview_i32_6d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i32_6d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i32_6d_t
+
+  type(c_ptr) function view_ptr_dualview_i64_6d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i64_6d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i64_6d_t
+
+  type(c_ptr) function view_ptr_dualview_r32_6d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r32_6d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r32_6d_t
+
+  type(c_ptr) function view_ptr_dualview_r64_6d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r64_6d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r64_6d_t
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! view_ptr_dualview 7d implementations
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  type(c_ptr) function view_ptr_dualview_l_7d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_l_7d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_l_7d_t
+
+  type(c_ptr) function view_ptr_dualview_i32_7d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i32_7d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i32_7d_t
+
+  type(c_ptr) function view_ptr_dualview_i64_7d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_i64_7d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_i64_7d_t
+
+  type(c_ptr) function view_ptr_dualview_r32_7d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r32_7d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r32_7d_t
+
+  type(c_ptr) function view_ptr_dualview_r64_7d_t( self ) result( result_ptr )
+    implicit none
+    class( dualview_r64_7d_t ), intent(in) :: self
+    result_ptr = self%handle
+  end function view_ptr_dualview_r64_7d_t
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! fin
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/test/flcl-test-cxx.cpp
+++ b/test/flcl-test-cxx.cpp
@@ -2575,7 +2575,7 @@ extern "C" {
         for (size_t kk = 0; kk < array_i64_5d.extent(2); kk++) {
           for (size_t ll = 0; ll < array_i64_5d.extent(3); ll++) {
             for (size_t mm = 0; mm < array_i64_5d.extent(4); mm++) {
-            *c_sum += array_i64_5d(ii,jj,kk,ll,mm);
+              *c_sum += array_i64_5d(ii,jj,kk,ll,mm);
             }
           }
         }
@@ -3600,6 +3600,1002 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     }, *c_sum );
     array_r64_3d.template modify<typename view_type::execution_space>();
     array_r64_3d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **v_array_l_4d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_l_4d_t;
+    *c_sum = 0;
+    auto array_l_4d = **v_array_l_4d;
+    array_l_4d.template modify<typename view_type::host_mirror_space>();
+    array_l_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_4d_get", array_l_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_l_4d.extent(1); jj++) { 
+        for (size_t kk = 0; kk < array_l_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_4d.extent(3); ll++) {
+            if (array_l_4d.d_view(idx,jj,kk,ll)) temp_sum++;
+          }
+        }
+      }
+    }, *c_sum );
+    
+    array_l_4d.template modify<typename view_type::execution_space>();
+    array_l_4d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_l_4d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    array_l_4d.template modify<typename view_type::host_mirror_space>();
+    array_l_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_for( "c_test_kokkos_allocate_dualview_l_4d_set", array_l_4d.extent(0), KOKKOS_LAMBDA( const size_t idx)
+    {
+      for (size_t jj = 0; jj < array_l_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_l_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_4d.extent(3); ll++) {
+            array_l_4d.d_view(idx,jj,kk,ll) = logical_post;
+          }
+        }
+      }
+    });
+    array_l_4d.template modify<typename view_type::execution_space>();
+    array_l_4d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_4d( flcl::dualview_i32_4d_t **v_array_i32_4d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i32_4d_t;
+    *c_sum = 0;
+    auto array_i32_4d = **v_array_i32_4d;
+    array_i32_4d.template modify<typename view_type::host_mirror_space>();
+    array_i32_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_4d_get", array_i32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_4d.extent(3); ll++) {
+            temp_sum += array_i32_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_4d.template modify<typename view_type::execution_space>();
+    array_i32_4d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i32_4d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i32_4d.template modify<typename view_type::host_mirror_space>();
+    array_i32_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_4d_set", array_i32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_4d.extent(3); ll++) {
+            array_i32_4d.d_view(idx,jj,kk,ll) = idx+jj+kk+ll;
+            temp_sum += array_i32_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_4d.template modify<typename view_type::execution_space>();
+    array_i32_4d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_4d( flcl::dualview_i64_4d_t **v_array_i64_4d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i64_4d_t;
+    *c_sum = 0;
+    auto array_i64_4d = **v_array_i64_4d;
+    array_i64_4d.template modify<typename view_type::host_mirror_space>();
+    array_i64_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_4d_get", array_i64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_4d.extent(3); ll++) {
+            temp_sum += array_i64_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_4d.template modify<typename view_type::execution_space>();
+    array_i64_4d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i64_4d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i64_4d.template modify<typename view_type::host_mirror_space>();
+    array_i64_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_4d_set", array_i64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_4d.extent(3); ll++) {
+            array_i64_4d.d_view(idx,jj,kk,ll) = idx+jj+kk+ll;
+            temp_sum += array_i64_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_4d.template modify<typename view_type::execution_space>();
+    array_i64_4d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_4d( flcl::dualview_r32_4d_t **v_array_r32_4d, float *f_sum, float *c_sum ) {
+    using view_type = flcl::dualview_r32_4d_t;
+    *c_sum = 0;
+    auto array_r32_4d = **v_array_r32_4d;
+    array_r32_4d.template modify<typename view_type::host_mirror_space>();
+    array_r32_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_4d_get", array_r32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_4d.extent(3); ll++) {
+            temp_sum += array_r32_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_4d.template modify<typename view_type::execution_space>();
+    array_r32_4d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r32_4d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r32_4d.template modify<typename view_type::host_mirror_space>();
+    array_r32_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_4d_set", array_r32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_4d.extent(3); ll++) {
+            array_r32_4d.d_view(idx,jj,kk,ll) = idx+jj+kk+ll;
+            temp_sum += array_r32_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_4d.template modify<typename view_type::execution_space>();
+    array_r32_4d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_4d( flcl::dualview_r64_4d_t **v_array_r64_4d, double *f_sum, double *c_sum ) {
+    using view_type = flcl::dualview_r64_4d_t;
+    *c_sum = 0;
+    auto array_r64_4d = **v_array_r64_4d;
+    array_r64_4d.template modify<typename view_type::host_mirror_space>();
+    array_r64_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_4d_get", array_r64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_4d.extent(3); ll++) {
+            temp_sum += array_r64_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_4d.template modify<typename view_type::execution_space>();
+    array_r64_4d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r64_4d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r64_4d.template modify<typename view_type::host_mirror_space>();
+    array_r64_4d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_4d_set", array_r64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_4d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_4d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_4d.extent(3); ll++) {
+            array_r64_4d.d_view(idx,jj,kk,ll) = idx+jj+kk+ll;
+            temp_sum += array_r64_4d.d_view(idx,jj,kk,ll);
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_4d.template modify<typename view_type::execution_space>();
+    array_r64_4d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **v_array_l_5d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_l_5d_t;
+    *c_sum = 0;
+    auto array_l_5d = **v_array_l_5d;
+    array_l_5d.template modify<typename view_type::host_mirror_space>();
+    array_l_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_5d_get", array_l_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_l_5d.extent(1); jj++) { 
+        for (size_t kk = 0; kk < array_l_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_l_5d.extent(4); mm++) {
+              if (array_l_5d.d_view(idx,jj,kk,ll,mm)) temp_sum++;
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    
+    array_l_5d.template modify<typename view_type::execution_space>();
+    array_l_5d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_l_5d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    array_l_5d.template modify<typename view_type::host_mirror_space>();
+    array_l_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_for( "c_test_kokkos_allocate_dualview_l_5d_set", array_l_5d.extent(0), KOKKOS_LAMBDA( const size_t idx)
+    {
+      for (size_t jj = 0; jj < array_l_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_l_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_l_5d.extent(4); mm++) {
+              array_l_5d.d_view(idx,jj,kk,ll,mm) = logical_post;
+            }
+          }
+        }
+      }
+    });
+    array_l_5d.template modify<typename view_type::execution_space>();
+    array_l_5d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_5d( flcl::dualview_i32_5d_t **v_array_i32_5d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i32_5d_t;
+    *c_sum = 0;
+    auto array_i32_5d = **v_array_i32_5d;
+    array_i32_5d.template modify<typename view_type::host_mirror_space>();
+    array_i32_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_5d_get", array_i32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i32_5d.extent(4); mm++) {
+              temp_sum += array_i32_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_5d.template modify<typename view_type::execution_space>();
+    array_i32_5d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i32_5d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i32_5d.template modify<typename view_type::host_mirror_space>();
+    array_i32_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_5d_set", array_i32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i32_5d.extent(4); mm++) {
+              array_i32_5d.d_view(idx,jj,kk,ll,mm) = idx+jj+kk+ll+mm;
+              temp_sum += array_i32_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_5d.template modify<typename view_type::execution_space>();
+    array_i32_5d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_5d( flcl::dualview_i64_5d_t **v_array_i64_5d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i64_5d_t;
+    *c_sum = 0;
+    auto array_i64_5d = **v_array_i64_5d;
+    array_i64_5d.template modify<typename view_type::host_mirror_space>();
+    array_i64_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_5d_get", array_i64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i64_5d.extent(4); mm++) {
+              temp_sum += array_i64_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_5d.template modify<typename view_type::execution_space>();
+    array_i64_5d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i64_5d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i64_5d.template modify<typename view_type::host_mirror_space>();
+    array_i64_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_5d_set", array_i64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i64_5d.extent(4); mm++) {
+              array_i64_5d.d_view(idx,jj,kk,ll,mm) = idx+jj+kk+ll+mm;
+              temp_sum += array_i64_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_5d.template modify<typename view_type::execution_space>();
+    array_i64_5d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_5d( flcl::dualview_r32_5d_t **v_array_r32_5d, float *f_sum, float *c_sum ) {
+    using view_type = flcl::dualview_r32_5d_t;
+    *c_sum = 0;
+    auto array_r32_5d = **v_array_r32_5d;
+    array_r32_5d.template modify<typename view_type::host_mirror_space>();
+    array_r32_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_5d_get", array_r32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r32_5d.extent(4); mm++) {
+              temp_sum += array_r32_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_5d.template modify<typename view_type::execution_space>();
+    array_r32_5d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r32_5d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r32_5d.template modify<typename view_type::host_mirror_space>();
+    array_r32_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_5d_set", array_r32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r32_5d.extent(4); mm++) {
+              array_r32_5d.d_view(idx,jj,kk,ll,mm) = idx+jj+kk+ll+mm;
+              temp_sum += array_r32_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_5d.template modify<typename view_type::execution_space>();
+    array_r32_5d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_5d( flcl::dualview_r64_5d_t **v_array_r64_5d, double *f_sum, double *c_sum ) {
+    using view_type = flcl::dualview_r64_5d_t;
+    *c_sum = 0;
+    auto array_r64_5d = **v_array_r64_5d;
+    array_r64_5d.template modify<typename view_type::host_mirror_space>();
+    array_r64_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_5d_get", array_r64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r64_5d.extent(4); mm++) {
+              temp_sum += array_r64_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_5d.template modify<typename view_type::execution_space>();
+    array_r64_5d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r64_5d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r64_5d.template modify<typename view_type::host_mirror_space>();
+    array_r64_5d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_5d_set", array_r64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_5d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_5d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_5d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r64_5d.extent(4); mm++) {
+              array_r64_5d.d_view(idx,jj,kk,ll,mm) = idx+jj+kk+ll+mm;
+              temp_sum += array_r64_5d.d_view(idx,jj,kk,ll,mm);
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_5d.template modify<typename view_type::execution_space>();
+    array_r64_5d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **v_array_l_6d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_l_6d_t;
+    *c_sum = 0;
+    auto array_l_6d = **v_array_l_6d;
+    array_l_6d.template modify<typename view_type::host_mirror_space>();
+    array_l_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_6d_get", array_l_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_l_6d.extent(1); jj++) { 
+        for (size_t kk = 0; kk < array_l_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_l_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_l_6d.extent(5); nn++) {
+                if (array_l_6d.d_view(idx,jj,kk,ll,mm,nn)) temp_sum++;
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    
+    array_l_6d.template modify<typename view_type::execution_space>();
+    array_l_6d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_l_6d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    array_l_6d.template modify<typename view_type::host_mirror_space>();
+    array_l_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_for( "c_test_kokkos_allocate_dualview_l_6d_set", array_l_6d.extent(0), KOKKOS_LAMBDA( const size_t idx)
+    {
+      for (size_t jj = 0; jj < array_l_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_l_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_l_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_l_6d.extent(5); nn++) {
+                array_l_6d.d_view(idx,jj,kk,ll,mm,nn) = logical_post;
+              }
+            }
+          }
+        }
+      }
+    });
+    array_l_6d.template modify<typename view_type::execution_space>();
+    array_l_6d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_6d( flcl::dualview_i32_6d_t **v_array_i32_6d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i32_6d_t;
+    *c_sum = 0;
+    auto array_i32_6d = **v_array_i32_6d;
+    array_i32_6d.template modify<typename view_type::host_mirror_space>();
+    array_i32_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_6d_get", array_i32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i32_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i32_6d.extent(5); nn++) {
+                temp_sum += array_i32_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_6d.template modify<typename view_type::execution_space>();
+    array_i32_6d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i32_6d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i32_6d.template modify<typename view_type::host_mirror_space>();
+    array_i32_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_6d_set", array_i32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i32_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i32_6d.extent(5); nn++) {
+                array_i32_6d.d_view(idx,jj,kk,ll,mm,nn) = idx+jj+kk+ll+mm+nn;
+                temp_sum += array_i32_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_6d.template modify<typename view_type::execution_space>();
+    array_i32_6d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_6d( flcl::dualview_i64_6d_t **v_array_i64_6d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i64_6d_t;
+    *c_sum = 0;
+    auto array_i64_6d = **v_array_i64_6d;
+    array_i64_6d.template modify<typename view_type::host_mirror_space>();
+    array_i64_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_6d_get", array_i64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i64_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i64_6d.extent(5); nn++) {
+                temp_sum += array_i64_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_6d.template modify<typename view_type::execution_space>();
+    array_i64_6d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i64_6d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i64_6d.template modify<typename view_type::host_mirror_space>();
+    array_i64_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_6d_set", array_i64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i64_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i64_6d.extent(5); nn++) {
+                array_i64_6d.d_view(idx,jj,kk,ll,mm,nn) = idx+jj+kk+ll+mm+nn;
+                temp_sum += array_i64_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_6d.template modify<typename view_type::execution_space>();
+    array_i64_6d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_6d( flcl::dualview_r32_6d_t **v_array_r32_6d, float *f_sum, float *c_sum ) {
+    using view_type = flcl::dualview_r32_6d_t;
+    *c_sum = 0;
+    auto array_r32_6d = **v_array_r32_6d;
+    array_r32_6d.template modify<typename view_type::host_mirror_space>();
+    array_r32_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_6d_get", array_r32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r32_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r32_6d.extent(5); nn++) {
+                temp_sum += array_r32_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_6d.template modify<typename view_type::execution_space>();
+    array_r32_6d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r32_6d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r32_6d.template modify<typename view_type::host_mirror_space>();
+    array_r32_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_6d_set", array_r32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r32_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r32_6d.extent(5); nn++) {
+                array_r32_6d.d_view(idx,jj,kk,ll,mm,nn) = idx+jj+kk+ll+mm+nn;
+                temp_sum += array_r32_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_6d.template modify<typename view_type::execution_space>();
+    array_r32_6d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_6d( flcl::dualview_r64_6d_t **v_array_r64_6d, double *f_sum, double *c_sum ) {
+    using view_type = flcl::dualview_r64_6d_t;
+    *c_sum = 0;
+    auto array_r64_6d = **v_array_r64_6d;
+    array_r64_6d.template modify<typename view_type::host_mirror_space>();
+    array_r64_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_6d_get", array_r64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r64_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r64_6d.extent(5); nn++) {
+                temp_sum += array_r64_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_6d.template modify<typename view_type::execution_space>();
+    array_r64_6d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r64_6d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r64_6d.template modify<typename view_type::host_mirror_space>();
+    array_r64_6d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_6d_set", array_r64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_6d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_6d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_6d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r64_6d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r64_6d.extent(5); nn++) {
+                array_r64_6d.d_view(idx,jj,kk,ll,mm,nn) = idx+jj+kk+ll+mm+nn;
+                temp_sum += array_r64_6d.d_view(idx,jj,kk,ll,mm,nn);
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_6d.template modify<typename view_type::execution_space>();
+    array_r64_6d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **v_array_l_7d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_l_7d_t;
+    *c_sum = 0;
+    auto array_l_7d = **v_array_l_7d;
+    array_l_7d.template modify<typename view_type::host_mirror_space>();
+    array_l_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_7d_get", array_l_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_l_7d.extent(1); jj++) { 
+        for (size_t kk = 0; kk < array_l_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_l_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_l_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_l_7d.extent(6); oo++) {
+                  if (array_l_7d.d_view(idx,jj,kk,ll,mm,nn,oo)) temp_sum++;
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    
+    array_l_7d.template modify<typename view_type::execution_space>();
+    array_l_7d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_l_7d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    array_l_7d.template modify<typename view_type::host_mirror_space>();
+    array_l_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_for( "c_test_kokkos_allocate_dualview_l_7d_set", array_l_7d.extent(0), KOKKOS_LAMBDA( const size_t idx)
+    {
+      for (size_t jj = 0; jj < array_l_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_l_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_l_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_l_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_l_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_l_7d.extent(6); oo++) {
+                  array_l_7d.d_view(idx,jj,kk,ll,mm,nn,oo) = logical_post;
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+    array_l_7d.template modify<typename view_type::execution_space>();
+    array_l_7d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_7d( flcl::dualview_i32_7d_t **v_array_i32_7d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i32_7d_t;
+    *c_sum = 0;
+    auto array_i32_7d = **v_array_i32_7d;
+    array_i32_7d.template modify<typename view_type::host_mirror_space>();
+    array_i32_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_7d_get", array_i32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i32_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i32_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_i32_7d.extent(6); oo++) {
+                  temp_sum += array_i32_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_7d.template modify<typename view_type::execution_space>();
+    array_i32_7d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i32_7d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i32_7d.template modify<typename view_type::host_mirror_space>();
+    array_i32_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_7d_set", array_i32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i32_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i32_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i32_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i32_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i32_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_i32_7d.extent(6); oo++) {
+                  array_i32_7d.d_view(idx,jj,kk,ll,mm,nn,oo) = idx+jj+kk+ll+mm+nn+oo;
+                  temp_sum += array_i32_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i32_7d.template modify<typename view_type::execution_space>();
+    array_i32_7d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_7d( flcl::dualview_i64_7d_t **v_array_i64_7d, size_t *f_sum, size_t *c_sum ) {
+    using view_type = flcl::dualview_i64_7d_t;
+    *c_sum = 0;
+    auto array_i64_7d = **v_array_i64_7d;
+    array_i64_7d.template modify<typename view_type::host_mirror_space>();
+    array_i64_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_7d_get", array_i64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i64_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i64_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_i64_7d.extent(6); oo++) {
+                  temp_sum += array_i64_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_7d.template modify<typename view_type::execution_space>();
+    array_i64_7d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_i64_7d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_i64_7d.template modify<typename view_type::host_mirror_space>();
+    array_i64_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_7d_set", array_i64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_i64_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_i64_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_i64_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_i64_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_i64_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_i64_7d.extent(6); oo++) {
+                  array_i64_7d.d_view(idx,jj,kk,ll,mm,nn,oo) = idx+jj+kk+ll+mm+nn+oo;
+                  temp_sum += array_i64_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_i64_7d.template modify<typename view_type::execution_space>();
+    array_i64_7d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_7d( flcl::dualview_r32_7d_t **v_array_r32_7d, float *f_sum, float *c_sum ) {
+    using view_type = flcl::dualview_r32_7d_t;
+    *c_sum = 0;
+    auto array_r32_7d = **v_array_r32_7d;
+    array_r32_7d.template modify<typename view_type::host_mirror_space>();
+    array_r32_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_7d_get", array_r32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r32_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r32_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_r32_7d.extent(6); oo++) {
+                  temp_sum += array_r32_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_7d.template modify<typename view_type::execution_space>();
+    array_r32_7d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r32_7d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r32_7d.template modify<typename view_type::host_mirror_space>();
+    array_r32_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_7d_set", array_r32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r32_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r32_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r32_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r32_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r32_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_r32_7d.extent(6); oo++) {
+                  array_r32_7d.d_view(idx,jj,kk,ll,mm,nn,oo) = idx+jj+kk+ll+mm+nn+oo;
+                  temp_sum += array_r32_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r32_7d.template modify<typename view_type::execution_space>();
+    array_r32_7d.template sync<typename view_type::host_mirror_space>();
+
+    return FLCL_TEST_PASS;
+  }
+
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_7d( flcl::dualview_r64_7d_t **v_array_r64_7d, double *f_sum, double *c_sum ) {
+    using view_type = flcl::dualview_r64_7d_t;
+    *c_sum = 0;
+    auto array_r64_7d = **v_array_r64_7d;
+    array_r64_7d.template modify<typename view_type::host_mirror_space>();
+    array_r64_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_7d_get", array_r64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r64_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r64_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_r64_7d.extent(6); oo++) {
+                  temp_sum += array_r64_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_7d.template modify<typename view_type::execution_space>();
+    array_r64_7d.template sync<typename view_type::host_mirror_space>();
+    
+    if (*c_sum != *f_sum) {
+      std::cout << "FAILED C kokkos_allocate_dualview_r64_7d" << std::endl;
+      return FLCL_TEST_FAIL;
+    }
+    
+    *c_sum = 0;
+    array_r64_7d.template modify<typename view_type::host_mirror_space>();
+    array_r64_7d.template sync<typename view_type::execution_space>();
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_7d_set", array_r64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    {
+      for (size_t jj = 0; jj < array_r64_7d.extent(1); jj++) {
+        for (size_t kk = 0; kk < array_r64_7d.extent(2); kk++) {
+          for (size_t ll = 0; ll < array_r64_7d.extent(3); ll++) {
+            for (size_t mm = 0; mm < array_r64_7d.extent(4); mm++) {
+              for (size_t nn = 0; nn < array_r64_7d.extent(5); nn++) {
+                for (size_t oo = 0; oo < array_r64_7d.extent(6); oo++) {
+                  array_r64_7d.d_view(idx,jj,kk,ll,mm,nn,oo) = idx+jj+kk+ll+mm+nn+oo;
+                  temp_sum += array_r64_7d.d_view(idx,jj,kk,ll,mm,nn,oo);
+                }
+              }
+            }
+          }
+        }
+      }
+    }, *c_sum );
+    array_r64_7d.template modify<typename view_type::execution_space>();
+    array_r64_7d.template sync<typename view_type::host_mirror_space>();
 
     return FLCL_TEST_PASS;
   }

--- a/test/flcl-test-f.F90
+++ b/test/flcl-test-f.F90
@@ -1215,6 +1215,246 @@ module flcl_test_f_mod
       end function f_test_kokkos_allocate_dualview_r64_3d
     end interface
 
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_l_4d( v_array_l_4d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_l_4d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_l_4d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_l_4d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i32_4d( v_array_i32_4d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i32_4d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i32_4d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i32_4d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i64_4d( v_array_i64_4d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i64_4d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i64_4d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i64_4d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r32_4d( v_array_r32_4d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r32_4d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r32_4d
+        real(c_float), intent(inout) :: f_sum
+        real(c_float), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r32_4d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r64_4d( v_array_r64_4d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r64_4d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r64_4d
+        real(c_double), intent(inout) :: f_sum
+        real(c_double), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r64_4d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_l_5d( v_array_l_5d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_l_5d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_l_5d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_l_5d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i32_5d( v_array_i32_5d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i32_5d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i32_5d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i32_5d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i64_5d( v_array_i64_5d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i64_5d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i64_5d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i64_5d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r32_5d( v_array_r32_5d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r32_5d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r32_5d
+        real(c_float), intent(inout) :: f_sum
+        real(c_float), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r32_5d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r64_5d( v_array_r64_5d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r64_5d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r64_5d
+        real(c_double), intent(inout) :: f_sum
+        real(c_double), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r64_5d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_l_6d( v_array_l_6d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_l_6d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_l_6d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_l_6d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i32_6d( v_array_i32_6d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i32_6d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i32_6d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i32_6d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i64_6d( v_array_i64_6d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i64_6d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i64_6d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i64_6d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r32_6d( v_array_r32_6d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r32_6d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r32_6d
+        real(c_float), intent(inout) :: f_sum
+        real(c_float), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r32_6d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r64_6d( v_array_r64_6d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r64_6d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r64_6d
+        real(c_double), intent(inout) :: f_sum
+        real(c_double), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r64_6d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_l_7d( v_array_l_7d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_l_7d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_l_7d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_l_7d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i32_7d( v_array_i32_7d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i32_7d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i32_7d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i32_7d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_i64_7d( v_array_i64_7d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_i64_7d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_i64_7d
+        integer(c_size_t), intent(inout) :: f_sum
+        integer(c_size_t), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_i64_7d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r32_7d( v_array_r32_7d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r32_7d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r32_7d
+        real(c_float), intent(inout) :: f_sum
+        real(c_float), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r32_7d
+    end interface
+
+    interface
+      integer &
+        & function f_test_kokkos_allocate_dualview_r64_7d( v_array_r64_7d, f_sum, c_sum ) &
+        & bind(c, name='c_test_kokkos_allocate_dualview_r64_7d')
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        type(c_ptr), intent(in) :: v_array_r64_7d
+        real(c_double), intent(inout) :: f_sum
+        real(c_double), intent(inout) :: c_sum
+      end function f_test_kokkos_allocate_dualview_r64_7d
+    end interface
+
     contains
 
       integer(c_size_t) &
@@ -6069,5 +6309,1176 @@ module flcl_test_f_mod
         end if
         call kokkos_deallocate_dualview( array_r64_3d, v_array_r64_3d )
       end function test_kokkos_allocate_dualview_r64_3d
+
+      integer &
+        & function test_kokkos_allocate_dualview_l_4d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        logical(c_bool), pointer, dimension(:,:,:,:)  :: array_l_4d
+        type(dualview_l_4d_t) :: v_array_l_4d
+        integer :: ii, jj, kk, ll
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_l_4d, v_array_l_4d, 'array_l_4d', e0_length, e1_length, e2_length, e3_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                array_l_4d(ii,jj,kk,ll) = logical_pre
+                if (array_l_4d(ii,jj,kk,ll) .eqv. logical_pre) then
+                  f_sum = f_sum + 1
+                end if
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_l_4d( v_array_l_4d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  if (array_l_4d(ii,jj,kk,ll) .eqv. logical_post) then
+                    f_sum = f_sum + 1
+                  end if
+                end do
+              end do
+            end do
+          end do
+          if (f_sum == c_sum) then
+            write(*,*)'PASSED kokkos_allocate_dualview_l_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_l_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_l_4d, v_array_l_4d )
+      end function test_kokkos_allocate_dualview_l_4d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i32_4d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int32_t), pointer, dimension(:,:,:,:)  :: array_i32_4d
+        type(dualview_i32_4d_t) :: v_array_i32_4d
+        integer :: ii, jj, kk, ll
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i32_4d, v_array_i32_4d, 'array_i32_4d', e0_length, e1_length, e2_length, e3_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                array_i32_4d(ii,jj,kk,ll) = ii+jj+kk+ll
+                f_sum = f_sum + array_i32_4d(ii,jj,kk,ll)
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i32_4d( v_array_i32_4d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  f_sum = f_sum + array_i32_4d(ii,jj,kk,ll)
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i32_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i32_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i32_4d, v_array_i32_4d )
+      end function test_kokkos_allocate_dualview_i32_4d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i64_4d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int64_t), pointer, dimension(:,:,:,:)  :: array_i64_4d
+        type(dualview_i64_4d_t) :: v_array_i64_4d
+        integer :: ii, jj, kk, ll
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i64_4d, v_array_i64_4d, 'array_i64_4d', e0_length, e1_length, e2_length, e3_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                array_i64_4d(ii,jj,kk,ll) = ii+jj+kk+ll
+                f_sum = f_sum + array_i64_4d(ii,jj,kk,ll)
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i64_4d( v_array_i64_4d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  f_sum = f_sum + array_i64_4d(ii,jj,kk,ll)
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i64_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i64_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i64_4d, v_array_i64_4d )
+      end function test_kokkos_allocate_dualview_i64_4d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r32_4d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_float), pointer, dimension(:,:,:,:)  :: array_r32_4d
+        type(dualview_r32_4d_t) :: v_array_r32_4d
+        integer :: ii, jj, kk, ll
+        real(c_float) :: f_sum = 0
+        real(c_float) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r32_4d, v_array_r32_4d, 'array_r32_4d', e0_length, e1_length, e2_length, e3_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                array_r32_4d(ii,jj,kk,ll) = ii+jj+kk+ll
+                f_sum = f_sum + array_r32_4d(ii,jj,kk,ll)
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r32_4d( v_array_r32_4d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  f_sum = f_sum + array_r32_4d(ii,jj,kk,ll)
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r32_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r32_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r32_4d, v_array_r32_4d )
+      end function test_kokkos_allocate_dualview_r32_4d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r64_4d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_double), pointer, dimension(:,:,:,:)  :: array_r64_4d
+        type(dualview_r64_4d_t) :: v_array_r64_4d
+        integer :: ii, jj, kk, ll
+        real(c_double) :: f_sum = 0
+        real(c_double) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r64_4d, v_array_r64_4d, 'array_r64_4d', e0_length, e1_length, e2_length, e3_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                array_r64_4d(ii,jj,kk,ll) = ii+jj+kk+ll
+                f_sum = f_sum + array_r64_4d(ii,jj,kk,ll)
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r64_4d( v_array_r64_4d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  f_sum = f_sum + array_r64_4d(ii,jj,kk,ll)
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r64_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r64_4d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r64_4d, v_array_r64_4d )
+      end function test_kokkos_allocate_dualview_r64_4d
+
+      integer &
+        & function test_kokkos_allocate_dualview_l_5d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        logical(c_bool), pointer, dimension(:,:,:,:,:)  :: array_l_5d
+        type(dualview_l_5d_t) :: v_array_l_5d
+        integer :: ii, jj, kk, ll, mm
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_l_5d, v_array_l_5d, 'array_l_5d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  array_l_5d(ii,jj,kk,ll,mm) = logical_pre
+                  if (array_l_5d(ii,jj,kk,ll,mm) .eqv. logical_pre) then
+                    f_sum = f_sum + 1
+                  end if
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_l_5d( v_array_l_5d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    if (array_l_5d(ii,jj,kk,ll,mm) .eqv. logical_post) then
+                      f_sum = f_sum + 1
+                    end if
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if (f_sum == c_sum) then
+            write(*,*)'PASSED kokkos_allocate_dualview_l_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_l_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_l_5d, v_array_l_5d )
+      end function test_kokkos_allocate_dualview_l_5d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i32_5d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int32_t), pointer, dimension(:,:,:,:,:)  :: array_i32_5d
+        type(dualview_i32_5d_t) :: v_array_i32_5d
+        integer :: ii, jj, kk, ll, mm
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i32_5d, v_array_i32_5d, 'array_i32_5d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  array_i32_5d(ii,jj,kk,ll,mm) = ii+jj+kk+ll+mm
+                  f_sum = f_sum + array_i32_5d(ii,jj,kk,ll,mm)
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i32_5d( v_array_i32_5d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    f_sum = f_sum + array_i32_5d(ii,jj,kk,ll,mm)
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i32_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i32_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i32_5d, v_array_i32_5d )
+      end function test_kokkos_allocate_dualview_i32_5d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i64_5d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int64_t), pointer, dimension(:,:,:,:,:)  :: array_i64_5d
+        type(dualview_i64_5d_t) :: v_array_i64_5d
+        integer :: ii, jj, kk, ll, mm
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i64_5d, v_array_i64_5d, 'array_i64_5d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  array_i64_5d(ii,jj,kk,ll,mm) = ii+jj+kk+ll+mm
+                  f_sum = f_sum + array_i64_5d(ii,jj,kk,ll,mm)
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i64_5d( v_array_i64_5d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    f_sum = f_sum + array_i64_5d(ii,jj,kk,ll,mm)
+                  end do 
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i64_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i64_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i64_5d, v_array_i64_5d )
+      end function test_kokkos_allocate_dualview_i64_5d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r32_5d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_float), pointer, dimension(:,:,:,:,:)  :: array_r32_5d
+        type(dualview_r32_5d_t) :: v_array_r32_5d
+        integer :: ii, jj, kk, ll, mm
+        real(c_float) :: f_sum = 0
+        real(c_float) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r32_5d, v_array_r32_5d, 'array_r32_5d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  array_r32_5d(ii,jj,kk,ll,mm) = ii+jj+kk+ll+mm
+                  f_sum = f_sum + array_r32_5d(ii,jj,kk,ll,mm)
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r32_5d( v_array_r32_5d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    f_sum = f_sum + array_r32_5d(ii,jj,kk,ll,mm)
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r32_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r32_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r32_5d, v_array_r32_5d )
+      end function test_kokkos_allocate_dualview_r32_5d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r64_5d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_double), pointer, dimension(:,:,:,:,:)  :: array_r64_5d
+        type(dualview_r64_5d_t) :: v_array_r64_5d
+        integer :: ii, jj, kk, ll, mm
+        real(c_double) :: f_sum = 0
+        real(c_double) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r64_5d, v_array_r64_5d, 'array_r64_5d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  array_r64_5d(ii,jj,kk,ll,mm) = ii+jj+kk+ll+mm
+                  f_sum = f_sum + array_r64_5d(ii,jj,kk,ll,mm)
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r64_5d( v_array_r64_5d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    f_sum = f_sum + array_r64_5d(ii,jj,kk,ll,mm)
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r64_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r64_5d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r64_5d, v_array_r64_5d )
+      end function test_kokkos_allocate_dualview_r64_5d
+
+      integer &
+        & function test_kokkos_allocate_dualview_l_6d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        logical(c_bool), pointer, dimension(:,:,:,:,:,:)  :: array_l_6d
+        type(dualview_l_6d_t) :: v_array_l_6d
+        integer :: ii, jj, kk, ll, mm, nn
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_l_6d, v_array_l_6d, 'array_l_6d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    array_l_6d(ii,jj,kk,ll,mm,nn) = logical_pre
+                    if (array_l_6d(ii,jj,kk,ll,mm,nn) .eqv. logical_pre) then
+                      f_sum = f_sum + 1
+                    end if
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_l_6d( v_array_l_6d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      if (array_l_6d(ii,jj,kk,ll,mm,nn) .eqv. logical_post) then
+                        f_sum = f_sum + 1
+                      end if
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if (f_sum == c_sum) then
+            write(*,*)'PASSED kokkos_allocate_dualview_l_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_l_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_l_6d, v_array_l_6d )
+      end function test_kokkos_allocate_dualview_l_6d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i32_6d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int32_t), pointer, dimension(:,:,:,:,:,:)  :: array_i32_6d
+        type(dualview_i32_6d_t) :: v_array_i32_6d
+        integer :: ii, jj, kk, ll, mm, nn
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i32_6d, v_array_i32_6d, 'array_i32_6d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    array_i32_6d(ii,jj,kk,ll,mm,nn) = ii+jj+kk+ll+mm+nn
+                    f_sum = f_sum + array_i32_6d(ii,jj,kk,ll,mm,nn)
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i32_6d( v_array_i32_6d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      f_sum = f_sum + array_i32_6d(ii,jj,kk,ll,mm,nn)
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i32_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i32_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i32_6d, v_array_i32_6d )
+      end function test_kokkos_allocate_dualview_i32_6d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i64_6d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int64_t), pointer, dimension(:,:,:,:,:,:)  :: array_i64_6d
+        type(dualview_i64_6d_t) :: v_array_i64_6d
+        integer :: ii, jj, kk, ll, mm, nn
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i64_6d, v_array_i64_6d, 'array_i64_6d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                      array_i64_6d(ii,jj,kk,ll,mm,nn) = ii+jj+kk+ll+mm+nn
+                      f_sum = f_sum + array_i64_6d(ii,jj,kk,ll,mm,nn)
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i64_6d( v_array_i64_6d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      f_sum = f_sum + array_i64_6d(ii,jj,kk,ll,mm,nn)
+                    end do
+                  end do 
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i64_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i64_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i64_6d, v_array_i64_6d )
+      end function test_kokkos_allocate_dualview_i64_6d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r32_6d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_float), pointer, dimension(:,:,:,:,:,:)  :: array_r32_6d
+        type(dualview_r32_6d_t) :: v_array_r32_6d
+        integer :: ii, jj, kk, ll, mm, nn
+        real(c_float) :: f_sum = 0
+        real(c_float) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r32_6d, v_array_r32_6d, 'array_r32_6d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    array_r32_6d(ii,jj,kk,ll,mm,nn) = ii+jj+kk+ll+mm+nn
+                    f_sum = f_sum + array_r32_6d(ii,jj,kk,ll,mm,nn)
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r32_6d( v_array_r32_6d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      f_sum = f_sum + array_r32_6d(ii,jj,kk,ll,mm,nn)
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r32_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r32_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r32_6d, v_array_r32_6d )
+      end function test_kokkos_allocate_dualview_r32_6d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r64_6d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_double), pointer, dimension(:,:,:,:,:,:)  :: array_r64_6d
+        type(dualview_r64_6d_t) :: v_array_r64_6d
+        integer :: ii, jj, kk, ll, mm, nn
+        real(c_double) :: f_sum = 0
+        real(c_double) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r64_6d, v_array_r64_6d, 'array_r64_6d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    array_r64_6d(ii,jj,kk,ll,mm,nn) = ii+jj+kk+ll+mm+nn
+                    f_sum = f_sum + array_r64_6d(ii,jj,kk,ll,mm,nn)
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r64_6d( v_array_r64_6d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      f_sum = f_sum + array_r64_6d(ii,jj,kk,ll,mm,nn)
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r64_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r64_6d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r64_6d, v_array_r64_6d )
+      end function test_kokkos_allocate_dualview_r64_6d
+
+      integer &
+        & function test_kokkos_allocate_dualview_l_7d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        logical(c_bool), pointer, dimension(:,:,:,:,:,:,:)  :: array_l_7d
+        type(dualview_l_7d_t) :: v_array_l_7d
+        integer :: ii, jj, kk, ll, mm, nn, oo
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_l_7d, v_array_l_7d, 'array_l_7d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    do oo = 1, e6_length
+                      array_l_7d(ii,jj,kk,ll,mm,nn,oo) = logical_pre
+                      if (array_l_7d(ii,jj,kk,ll,mm,nn,oo) .eqv. logical_pre) then
+                        f_sum = f_sum + 1
+                      end if
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_l_7d( v_array_l_7d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      do oo = 1, e6_length
+                        if (array_l_7d(ii,jj,kk,ll,mm,nn,oo) .eqv. logical_post) then
+                          f_sum = f_sum + 1
+                        end if
+                      end do
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if (f_sum == c_sum) then
+            write(*,*)'PASSED kokkos_allocate_dualview_l_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_l_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_l_7d, v_array_l_7d )
+      end function test_kokkos_allocate_dualview_l_7d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i32_7d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int32_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i32_7d
+        type(dualview_i32_7d_t) :: v_array_i32_7d
+        integer :: ii, jj, kk, ll, mm, nn, oo
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i32_7d, v_array_i32_7d, 'array_i32_7d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    do oo = 1, e6_length
+                      array_i32_7d(ii,jj,kk,ll,mm,nn,oo) = ii+jj+kk+ll+mm+nn+oo
+                      f_sum = f_sum + array_i32_7d(ii,jj,kk,ll,mm,nn,oo)
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i32_7d( v_array_i32_7d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      do oo = 1, e6_length
+                        f_sum = f_sum + array_i32_7d(ii,jj,kk,ll,mm,nn,oo)
+                      end do
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i32_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i32_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i32_7d, v_array_i32_7d )
+      end function test_kokkos_allocate_dualview_i32_7d
+
+      integer &
+        & function test_kokkos_allocate_dualview_i64_7d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        integer(c_int64_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i64_7d
+        type(dualview_i64_7d_t) :: v_array_i64_7d
+        integer :: ii, jj, kk, ll, mm, nn, oo
+        integer(c_size_t) :: f_sum = 0
+        integer(c_size_t) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_i64_7d, v_array_i64_7d, 'array_i64_7d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    do oo = 1, e6_length
+                      array_i64_7d(ii,jj,kk,ll,mm,nn,oo) = ii+jj+kk+ll+mm+nn+oo
+                      f_sum = f_sum + array_i64_7d(ii,jj,kk,ll,mm,nn,oo)
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_i64_7d( v_array_i64_7d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      do oo = 1, e6_length
+                        f_sum = f_sum + array_i64_7d(ii,jj,kk,ll,mm,nn,oo)
+                      end do
+                    end do
+                  end do 
+                end do
+              end do
+            end do
+          end do
+          if ( f_sum .eq. c_sum ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_i64_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_i64_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_i64_7d, v_array_i64_7d )
+      end function test_kokkos_allocate_dualview_i64_7d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r32_7d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_float), pointer, dimension(:,:,:,:,:,:,:)  :: array_r32_7d
+        type(dualview_r32_7d_t) :: v_array_r32_7d
+        integer :: ii, jj, kk, ll, mm, nn, oo
+        real(c_float) :: f_sum = 0
+        real(c_float) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r32_7d, v_array_r32_7d, 'array_r32_7d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    do oo = 1, e6_length
+                      array_r32_7d(ii,jj,kk,ll,mm,nn,oo) = ii+jj+kk+ll+mm+nn+oo
+                      f_sum = f_sum + array_r32_7d(ii,jj,kk,ll,mm,nn,oo)
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r32_7d( v_array_r32_7d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      do oo = 1, e6_length
+                        f_sum = f_sum + array_r32_7d(ii,jj,kk,ll,mm,nn,oo)
+                      end do
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r32_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r32_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r32_7d, v_array_r32_7d )
+      end function test_kokkos_allocate_dualview_r32_7d
+
+      integer &
+        & function test_kokkos_allocate_dualview_r64_7d() &
+        & result(ierr)
+        use, intrinsic :: iso_c_binding
+        use :: flcl_mod
+        implicit none
+
+        real(c_double), pointer, dimension(:,:,:,:,:,:,:)  :: array_r64_7d
+        type(dualview_r64_7d_t) :: v_array_r64_7d
+        integer :: ii, jj, kk, ll, mm, nn, oo
+        real(c_double) :: f_sum = 0
+        real(c_double) :: c_sum = 0
+
+        call kokkos_allocate_dualview( array_r64_7d, v_array_r64_7d, 'array_r64_7d', &
+          & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
+        do ii = 1, e0_length
+          do jj = 1, e1_length
+            do kk = 1, e2_length
+              do ll = 1, e3_length
+                do mm = 1, e4_length
+                  do nn = 1, e5_length
+                    do oo = 1, e6_length
+                      array_r64_7d(ii,jj,kk,ll,mm,nn,oo) = ii+jj+kk+ll+mm+nn+oo
+                      f_sum = f_sum + array_r64_7d(ii,jj,kk,ll,mm,nn,oo)
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+        end do
+        ierr = f_test_kokkos_allocate_dualview_r64_7d( v_array_r64_7d%ptr(), f_sum, c_sum )
+        if (ierr == flcl_test_pass) then
+          f_sum = 0
+          do ii = 1, e0_length
+            do jj = 1, e1_length
+              do kk = 1, e2_length
+                do ll = 1, e3_length
+                  do mm = 1, e4_length
+                    do nn = 1, e5_length
+                      do oo = 1, e6_length
+                      f_sum = f_sum + array_r64_7d(ii,jj,kk,ll,mm,nn,oo)
+                      end do
+                    end do
+                  end do
+                end do
+              end do
+            end do
+          end do
+          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+            write(*,*)'PASSED kokkos_allocate_dualview_r64_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_pass
+          else
+            write(*,*)'FAILED F kokkos_allocate_dualview_r64_7d'
+            write(*,*)'f_sum = ',f_sum
+            write(*,*)'c_sum = ',c_sum
+            ierr = flcl_test_fail
+          end if
+        end if
+        call kokkos_deallocate_dualview( array_r64_7d, v_array_r64_7d )
+      end function test_kokkos_allocate_dualview_r64_7d
 
 end module flcl_test_f_mod

--- a/test/test_kokkos_allocate_dualview_i32_4d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_4d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i32_4d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i32_4d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i32_4d_main

--- a/test/test_kokkos_allocate_dualview_i32_5d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_5d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i32_5d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i32_5d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i32_5d_main

--- a/test/test_kokkos_allocate_dualview_i32_6d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_6d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i32_6d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i32_6d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i32_6d_main

--- a/test/test_kokkos_allocate_dualview_i32_7d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_7d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i32_7d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i32_7d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i32_7d_main

--- a/test/test_kokkos_allocate_dualview_i64_4d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_4d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i64_4d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i64_4d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i64_4d_main

--- a/test/test_kokkos_allocate_dualview_i64_5d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_5d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i64_5d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i64_5d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i64_5d_main

--- a/test/test_kokkos_allocate_dualview_i64_6d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_6d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i64_6d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i64_6d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i64_6d_main

--- a/test/test_kokkos_allocate_dualview_i64_7d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_7d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_i64_7d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_i64_7d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_i64_7d_main

--- a/test/test_kokkos_allocate_dualview_l_4d.f90
+++ b/test/test_kokkos_allocate_dualview_l_4d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_l_4d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_l_4d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_l_4d_main

--- a/test/test_kokkos_allocate_dualview_l_5d.f90
+++ b/test/test_kokkos_allocate_dualview_l_5d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_l_5d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_l_5d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_l_5d_main

--- a/test/test_kokkos_allocate_dualview_l_6d.f90
+++ b/test/test_kokkos_allocate_dualview_l_6d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_l_6d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_l_6d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_l_6d_main

--- a/test/test_kokkos_allocate_dualview_l_7d.f90
+++ b/test/test_kokkos_allocate_dualview_l_7d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_l_7d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_l_7d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_l_7d_main

--- a/test/test_kokkos_allocate_dualview_r32_4d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_4d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r32_4d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r32_4d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r32_4d_main

--- a/test/test_kokkos_allocate_dualview_r32_5d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_5d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r32_5d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r32_5d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r32_5d_main

--- a/test/test_kokkos_allocate_dualview_r32_6d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_6d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r32_6d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r32_6d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r32_6d_main

--- a/test/test_kokkos_allocate_dualview_r32_7d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_7d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r32_7d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r32_7d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r32_7d_main

--- a/test/test_kokkos_allocate_dualview_r64_4d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_4d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r64_4d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r64_4d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r64_4d_main

--- a/test/test_kokkos_allocate_dualview_r64_5d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_5d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r64_5d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r64_5d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r64_5d_main

--- a/test/test_kokkos_allocate_dualview_r64_6d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_6d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r64_6d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r64_6d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r64_6d_main

--- a/test/test_kokkos_allocate_dualview_r64_7d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_7d.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+program test_kokkos_allocate_dualview_r64_7d_main
+    use, intrinsic :: iso_c_binding
+    use, intrinsic :: iso_fortran_env
+  
+    use :: flcl_mod
+    use :: flcl_util_kokkos_mod
+    use :: flcl_test_f_mod
+  
+    implicit none
+  
+    integer(c_size_t) :: ierr = 0
+  
+    write(*,*)'before kokkos_init'
+    call kokkos_initialize_without_args()
+    write(*,*)'after kokkos_init'
+
+    if ( kokkos_is_initialized() ) then
+      
+      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+  
+      ierr = test_kokkos_allocate_dualview_r64_7d()
+      write(*,*)'ierr ',ierr
+  
+      call kokkos_finalize()
+  
+      call exit(ierr)
+
+    end if
+    
+  end program test_kokkos_allocate_dualview_r64_7d_main


### PR DESCRIPTION
Adds kokkos_allocate_dualview / kokkos_deallocate_dualview support for 4d-7d x l,i32,i64,r32,r64 and associated unit tests.