### PR TITLE
Types for override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ add_link_options(LINKER:--disable-new-dtags)
 #flcl-fortran library
 add_library(flcl-fortran
     OBJECT
+        src/flcl-types-f.f90
         src/flcl-ndarray-f.f90
         src/flcl-view-f.f90
         src/flcl-dualview-f.f90

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(flcl-cxx
 )
 set(flcl-cxx-public-headers
     ${PROJECT_SOURCE_DIR}/src/flcl-cxx.hpp
+    ${PROJECT_SOURCE_DIR}/src/flcl-types-cxx.hpp
     ${PROJECT_SOURCE_DIR}/src/flcl-util-cxx.h
 )
 set_property(TARGET flcl-cxx PROPERTY CXX_STANDARD 14)

--- a/src/flcl-cxx.cpp
+++ b/src/flcl-cxx.cpp
@@ -37,41 +37,42 @@
 
 #include "flcl-cxx.hpp"
 
-size_t one = 1;
+flcl::flcl_view_index_c_t view_index_one = 1;
+flcl::flcl_dualview_index_c_t dualview_index_one = 1;
 
 extern "C" {
 
   // 1D flcl view allocation routines
-  void c_kokkos_allocate_v_l_1d(bool** A, flcl::view_l_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_v_l_1d(flcl::flcl_view_l_c_t** A, flcl::view_l_1d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_l_1d_t(c_label, e0t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i32_1d(int32_t** A, flcl::view_i32_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_v_i32_1d(flcl::flcl_view_i32_c_t** A, flcl::view_i32_1d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i32_1d_t(c_label, e0t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i64_1d(int64_t** A, flcl::view_i64_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_v_i64_1d(flcl::flcl_view_i64_c_t** A, flcl::view_i64_1d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i64_1d_t(c_label, e0t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r32_1d(float** A, flcl::view_r32_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_v_r32_1d(flcl::flcl_view_r32_c_t** A, flcl::view_r32_1d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r32_1d_t(c_label, e0t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r64_1d(double** A, flcl::view_r64_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_v_r64_1d(flcl::flcl_view_r64_c_t** A, flcl::view_r64_1d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r64_1d_t(c_label, e0t));
     *A = (*v_A)->data();
@@ -80,357 +81,357 @@ extern "C" {
   }
 
   // 2D flcl view allocation routines
-  void c_kokkos_allocate_v_l_2d(bool** A, flcl::view_l_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_v_l_2d(flcl::flcl_view_l_c_t** A, flcl::view_l_2d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_l_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i32_2d(int32_t** A, flcl::view_i32_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_v_i32_2d(flcl::flcl_view_i32_c_t** A, flcl::view_i32_2d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i32_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i64_2d(int64_t** A, flcl::view_i64_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_v_i64_2d(flcl::flcl_view_i64_c_t** A, flcl::view_i64_2d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i64_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r32_2d(float** A, flcl::view_r32_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_v_r32_2d(flcl::flcl_view_r32_c_t** A, flcl::view_r32_2d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r32_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r64_2d(double** A, flcl::view_r64_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_v_r64_2d(flcl::flcl_view_r64_c_t** A, flcl::view_r64_2d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r64_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->data();
   }
 
 // 3D flcl view allocation routines
-  void c_kokkos_allocate_v_l_3d(bool** A, flcl::view_l_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_v_l_3d(flcl::flcl_view_l_c_t** A, flcl::view_l_3d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_l_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i32_3d(int32_t** A, flcl::view_i32_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_v_i32_3d(flcl::flcl_view_i32_c_t** A, flcl::view_i32_3d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i32_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i64_3d(int64_t** A, flcl::view_i64_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_v_i64_3d(flcl::flcl_view_i64_c_t** A, flcl::view_i64_3d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i64_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r32_3d(float** A, flcl::view_r32_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_v_r32_3d(flcl::flcl_view_r32_c_t** A, flcl::view_r32_3d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r32_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r64_3d(double** A, flcl::view_r64_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_v_r64_3d(flcl::flcl_view_r64_c_t** A, flcl::view_r64_3d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r64_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->data();
   }
 
 // 4D flcl view allocation routines
-  void c_kokkos_allocate_v_l_4d(bool** A, flcl::view_l_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_v_l_4d(flcl::flcl_view_l_c_t** A, flcl::view_l_4d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_l_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i32_4d(int32_t** A, flcl::view_i32_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_v_i32_4d(flcl::flcl_view_i32_c_t** A, flcl::view_i32_4d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i32_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i64_4d(int64_t** A, flcl::view_i64_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_v_i64_4d(flcl::flcl_view_i64_c_t** A, flcl::view_i64_4d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i64_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r32_4d(float** A, flcl::view_r32_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_v_r32_4d(flcl::flcl_view_r32_c_t** A, flcl::view_r32_4d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r32_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r64_4d(double** A, flcl::view_r64_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_v_r64_4d(flcl::flcl_view_r64_c_t** A, flcl::view_r64_4d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r64_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->data();
   }
 
   // 5D flcl view allocation routines
-  void c_kokkos_allocate_v_l_5d(bool** A, flcl::view_l_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_v_l_5d(flcl::flcl_view_l_c_t** A, flcl::view_l_5d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_l_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i32_5d(int32_t** A, flcl::view_i32_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_v_i32_5d(flcl::flcl_view_i32_c_t** A, flcl::view_i32_5d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i32_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i64_5d(int64_t** A, flcl::view_i64_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_v_i64_5d(flcl::flcl_view_i64_c_t** A, flcl::view_i64_5d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i64_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r32_5d(float** A, flcl::view_r32_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_v_r32_5d(flcl::flcl_view_r32_c_t** A, flcl::view_r32_5d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r32_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r64_5d(double** A, flcl::view_r64_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_v_r64_5d(flcl::flcl_view_r64_c_t** A, flcl::view_r64_5d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r64_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->data();
   }
 
   // 6D flcl view allocation routines
-  void c_kokkos_allocate_v_l_6d(bool** A, flcl::view_l_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_v_l_6d(flcl::flcl_view_l_c_t** A, flcl::view_l_6d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_l_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i32_6d(int32_t** A, flcl::view_i32_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_v_i32_6d(flcl::flcl_view_i32_c_t** A, flcl::view_i32_6d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i32_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i64_6d(int64_t** A, flcl::view_i64_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_v_i64_6d(flcl::flcl_view_i64_c_t** A, flcl::view_i64_6d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i64_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r32_6d(float** A, flcl::view_r32_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_v_r32_6d(flcl::flcl_view_r32_c_t** A, flcl::view_r32_6d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r32_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r64_6d(double** A, flcl::view_r64_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_v_r64_6d(flcl::flcl_view_r64_c_t** A, flcl::view_r64_6d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r64_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->data();
   }
 
 // 7D flcl view allocation routines
-  void c_kokkos_allocate_v_l_7d(bool** A, flcl::view_l_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_v_l_7d(flcl::flcl_view_l_c_t** A, flcl::view_l_7d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5, const flcl::flcl_view_index_c_t* e6) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
+    const flcl::flcl_view_index_c_t e6t = std::max(*e6, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_l_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i32_7d(int32_t** A, flcl::view_i32_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_v_i32_7d(flcl::flcl_view_i32_c_t** A, flcl::view_i32_7d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5, const flcl::flcl_view_index_c_t* e6) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
+    const flcl::flcl_view_index_c_t e6t = std::max(*e6, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i32_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_i64_7d(int64_t** A, flcl::view_i64_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_v_i64_7d(flcl::flcl_view_i64_c_t** A, flcl::view_i64_7d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5, const flcl::flcl_view_index_c_t* e6) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
+    const flcl::flcl_view_index_c_t e6t = std::max(*e6, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_i64_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r32_7d(float** A, flcl::view_r32_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_v_r32_7d(flcl::flcl_view_r32_c_t** A, flcl::view_r32_7d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5, const flcl::flcl_view_index_c_t* e6) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
+    const flcl::flcl_view_index_c_t e6t = std::max(*e6, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r32_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->data();
   }
 
-  void c_kokkos_allocate_v_r64_7d(double** A, flcl::view_r64_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_v_r64_7d(flcl::flcl_view_r64_c_t** A, flcl::view_r64_7d_t** v_A, const char* f_label, const flcl::flcl_view_index_c_t* e0, const flcl::flcl_view_index_c_t* e1, const flcl::flcl_view_index_c_t* e2, const flcl::flcl_view_index_c_t* e3, const flcl::flcl_view_index_c_t* e4, const flcl::flcl_view_index_c_t* e5, const flcl::flcl_view_index_c_t* e6) {
+    const flcl::flcl_view_index_c_t e0t = std::max(*e0, view_index_one);
+    const flcl::flcl_view_index_c_t e1t = std::max(*e1, view_index_one);
+    const flcl::flcl_view_index_c_t e2t = std::max(*e2, view_index_one);
+    const flcl::flcl_view_index_c_t e3t = std::max(*e3, view_index_one);
+    const flcl::flcl_view_index_c_t e4t = std::max(*e4, view_index_one);
+    const flcl::flcl_view_index_c_t e5t = std::max(*e5, view_index_one);
+    const flcl::flcl_view_index_c_t e6t = std::max(*e6, view_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::view_r64_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->data();
   }
 
   // 1D flcl dualview allocation routines
-  void c_kokkos_allocate_dv_l_1d(bool** A, flcl::dualview_l_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_dv_l_1d(flcl::flcl_dualview_l_c_t** A, flcl::dualview_l_1d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_l_1d_t(c_label, e0t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i32_1d(int32_t** A, flcl::dualview_i32_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_dv_i32_1d(flcl::flcl_dualview_i32_c_t** A, flcl::dualview_i32_1d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i32_1d_t(c_label, e0t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i64_1d(int64_t** A, flcl::dualview_i64_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_dv_i64_1d(flcl::flcl_dualview_i64_c_t** A, flcl::dualview_i64_1d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i64_1d_t(c_label, e0t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r32_1d(float** A, flcl::dualview_r32_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_dv_r32_1d(flcl::flcl_dualview_r32_c_t** A, flcl::dualview_r32_1d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r32_1d_t(c_label, e0t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r64_1d(double** A, flcl::dualview_r64_1d_t** v_A, const char* f_label, const size_t* e0) {
-    const size_t e0t = std::max(*e0, one);
+  void c_kokkos_allocate_dv_r64_1d(flcl::flcl_dualview_r64_c_t** A, flcl::dualview_r64_1d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r64_1d_t(c_label, e0t));
     *A = (*v_A)->h_view.data();
@@ -439,321 +440,321 @@ extern "C" {
   }
 
   // 2D flcl dualview allocation routines
-  void c_kokkos_allocate_dv_l_2d(bool** A, flcl::dualview_l_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_dv_l_2d(flcl::flcl_dualview_l_c_t** A, flcl::dualview_l_2d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_l_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i32_2d(int32_t** A, flcl::dualview_i32_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_dv_i32_2d(flcl::flcl_dualview_i32_c_t** A, flcl::dualview_i32_2d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i32_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i64_2d(int64_t** A, flcl::dualview_i64_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_dv_i64_2d(flcl::flcl_dualview_i64_c_t** A, flcl::dualview_i64_2d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i64_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r32_2d(float** A, flcl::dualview_r32_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_dv_r32_2d(flcl::flcl_dualview_r32_c_t** A, flcl::dualview_r32_2d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r32_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r64_2d(double** A, flcl::dualview_r64_2d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
+  void c_kokkos_allocate_dv_r64_2d(flcl::flcl_dualview_r64_c_t** A, flcl::dualview_r64_2d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r64_2d_t(c_label, e0t, e1t));
     *A = (*v_A)->h_view.data();
   }
 
 // 3D flcl dualview allocation routines
-  void c_kokkos_allocate_dv_l_3d(bool** A, flcl::dualview_l_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_dv_l_3d(flcl::flcl_dualview_l_c_t** A, flcl::dualview_l_3d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_l_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i32_3d(int32_t** A, flcl::dualview_i32_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_dv_i32_3d(flcl::flcl_dualview_i32_c_t** A, flcl::dualview_i32_3d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i32_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i64_3d(int64_t** A, flcl::dualview_i64_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_dv_i64_3d(flcl::flcl_dualview_i64_c_t** A, flcl::dualview_i64_3d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i64_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r32_3d(float** A, flcl::dualview_r32_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_dv_r32_3d(flcl::flcl_dualview_r32_c_t** A, flcl::dualview_r32_3d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r32_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r64_3d(double** A, flcl::dualview_r64_3d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
+  void c_kokkos_allocate_dv_r64_3d(flcl::flcl_dualview_r64_c_t** A, flcl::dualview_r64_3d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r64_3d_t(c_label, e0t, e1t, e2t));
     *A = (*v_A)->h_view.data();
   }
 
 // 4D flcl dualview allocation routines
-  void c_kokkos_allocate_dv_l_4d(bool** A, flcl::dualview_l_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_dv_l_4d(flcl::flcl_dualview_l_c_t** A, flcl::dualview_l_4d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_l_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i32_4d(int32_t** A, flcl::dualview_i32_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_dv_i32_4d(flcl::flcl_dualview_i32_c_t** A, flcl::dualview_i32_4d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i32_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i64_4d(int64_t** A, flcl::dualview_i64_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_dv_i64_4d(flcl::flcl_dualview_i64_c_t** A, flcl::dualview_i64_4d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i64_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r32_4d(float** A, flcl::dualview_r32_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_dv_r32_4d(flcl::flcl_dualview_r32_c_t** A, flcl::dualview_r32_4d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r32_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r64_4d(double** A, flcl::dualview_r64_4d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
+  void c_kokkos_allocate_dv_r64_4d(flcl::flcl_dualview_r64_c_t** A, flcl::dualview_r64_4d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r64_4d_t(c_label, e0t, e1t, e2t, e3t));
     *A = (*v_A)->h_view.data();
   }
 
 // 5D flcl dualview allocation routines
-  void c_kokkos_allocate_dv_l_5d(bool** A, flcl::dualview_l_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_dv_l_5d(flcl::flcl_dualview_l_c_t** A, flcl::dualview_l_5d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_l_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i32_5d(int32_t** A, flcl::dualview_i32_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_dv_i32_5d(flcl::flcl_dualview_i32_c_t** A, flcl::dualview_i32_5d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i32_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i64_5d(int64_t** A, flcl::dualview_i64_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_dv_i64_5d(flcl::flcl_dualview_i64_c_t** A, flcl::dualview_i64_5d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i64_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r32_5d(float** A, flcl::dualview_r32_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_dv_r32_5d(flcl::flcl_dualview_r32_c_t** A, flcl::dualview_r32_5d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r32_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r64_5d(double** A, flcl::dualview_r64_5d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
+  void c_kokkos_allocate_dv_r64_5d(flcl::flcl_dualview_r64_c_t** A, flcl::dualview_r64_5d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r64_5d_t(c_label, e0t, e1t, e2t, e3t, e4t));
     *A = (*v_A)->h_view.data();
   }
 
 // 6D flcl dualview allocation routines
-  void c_kokkos_allocate_dv_l_6d(bool** A, flcl::dualview_l_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_dv_l_6d(flcl::flcl_dualview_l_c_t** A, flcl::dualview_l_6d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_l_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i32_6d(int32_t** A, flcl::dualview_i32_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_dv_i32_6d(flcl::flcl_dualview_i32_c_t** A, flcl::dualview_i32_6d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i32_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i64_6d(int64_t** A, flcl::dualview_i64_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_dv_i64_6d(flcl::flcl_dualview_i64_c_t** A, flcl::dualview_i64_6d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i64_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r32_6d(float** A, flcl::dualview_r32_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_dv_r32_6d(flcl::flcl_dualview_r32_c_t** A, flcl::dualview_r32_6d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r32_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r64_6d(double** A, flcl::dualview_r64_6d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
+  void c_kokkos_allocate_dv_r64_6d(flcl::flcl_dualview_r64_c_t** A, flcl::dualview_r64_6d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r64_6d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t));
     *A = (*v_A)->h_view.data();
   }
 
 // 7D flcl dualview allocation routines
-  void c_kokkos_allocate_dv_l_7d(bool** A, flcl::dualview_l_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_dv_l_7d(flcl::flcl_dualview_l_c_t** A, flcl::dualview_l_7d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5, const flcl::flcl_dualview_index_c_t* e6) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e6t = std::max(*e6, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_l_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i32_7d(int32_t** A, flcl::dualview_i32_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_dv_i32_7d(flcl::flcl_dualview_i32_c_t** A, flcl::dualview_i32_7d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5, const flcl::flcl_dualview_index_c_t* e6) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e6t = std::max(*e6, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i32_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_i64_7d(int64_t** A, flcl::dualview_i64_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_dv_i64_7d(flcl::flcl_dualview_i64_c_t** A, flcl::dualview_i64_7d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5, const flcl::flcl_dualview_index_c_t* e6) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e6t = std::max(*e6, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_i64_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r32_7d(float** A, flcl::dualview_r32_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_dv_r32_7d(flcl::flcl_dualview_r32_c_t** A, flcl::dualview_r32_7d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5, const flcl::flcl_dualview_index_c_t* e6) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e6t = std::max(*e6, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r32_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->h_view.data();
   }
 
-  void c_kokkos_allocate_dv_r64_7d(double** A, flcl::dualview_r64_7d_t** v_A, const char* f_label, const size_t* e0, const size_t* e1, const size_t* e2, const size_t* e3, const size_t* e4, const size_t* e5, const size_t* e6) {
-    const size_t e0t = std::max(*e0, one);
-    const size_t e1t = std::max(*e1, one);
-    const size_t e2t = std::max(*e2, one);
-    const size_t e3t = std::max(*e3, one);
-    const size_t e4t = std::max(*e4, one);
-    const size_t e5t = std::max(*e5, one);
-    const size_t e6t = std::max(*e6, one);
+  void c_kokkos_allocate_dv_r64_7d(flcl::flcl_dualview_r64_c_t** A, flcl::dualview_r64_7d_t** v_A, const char* f_label, const flcl::flcl_dualview_index_c_t* e0, const flcl::flcl_dualview_index_c_t* e1, const flcl::flcl_dualview_index_c_t* e2, const flcl::flcl_dualview_index_c_t* e3, const flcl::flcl_dualview_index_c_t* e4, const flcl::flcl_dualview_index_c_t* e5, const flcl::flcl_dualview_index_c_t* e6) {
+    const flcl::flcl_dualview_index_c_t e0t = std::max(*e0, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e1t = std::max(*e1, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e2t = std::max(*e2, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e3t = std::max(*e3, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e4t = std::max(*e4, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e5t = std::max(*e5, dualview_index_one);
+    const flcl::flcl_dualview_index_c_t e6t = std::max(*e6, dualview_index_one);
     std::string c_label( f_label );
     *v_A = (new flcl::dualview_r64_7d_t(c_label, e0t, e1t, e2t, e3t, e4t, e5t, e6t));
     *A = (*v_A)->h_view.data();

--- a/src/flcl-cxx.hpp
+++ b/src/flcl-cxx.hpp
@@ -45,14 +45,14 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_View.hpp>
 #include <Kokkos_DualView.hpp>
-
+#include "flcl-types-cxx.hpp"
 
 #define FLCL_NDARRAY_MAX_RANK 8
 
 typedef struct _flcl_nd_array_t {
-    size_t rank;
-    size_t dims[FLCL_NDARRAY_MAX_RANK];
-    size_t strides[FLCL_NDARRAY_MAX_RANK];
+    flcl::flcl_ndarray_index_c_t rank;
+    flcl::flcl_ndarray_index_c_t dims[FLCL_NDARRAY_MAX_RANK];
+    flcl::flcl_ndarray_index_c_t strides[FLCL_NDARRAY_MAX_RANK];
     void *data;
 } flcl_ndarray_t;
 
@@ -81,102 +81,102 @@ namespace flcl {
   #endif
 
   // 1D fortran-compatible view types
-  typedef Kokkos::View<bool*,Kokkos::LayoutLeft,flcl::HostMemorySpace>              view_l_1d_t;
-  typedef Kokkos::View<int32_t*,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_i32_1d_t;
-  typedef Kokkos::View<int64_t*,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_i64_1d_t;
-  typedef Kokkos::View<float*,Kokkos::LayoutLeft,flcl::HostMemorySpace>             view_r32_1d_t;
-  typedef Kokkos::View<double*,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_r64_1d_t;
+  typedef Kokkos::View<flcl_view_l_c_t*,Kokkos::LayoutLeft,flcl::HostMemorySpace>                 view_l_1d_t;
+  typedef Kokkos::View<flcl_view_i32_c_t*,Kokkos::LayoutLeft,flcl::HostMemorySpace>               view_i32_1d_t;
+  typedef Kokkos::View<flcl_view_i64_c_t*,Kokkos::LayoutLeft,flcl::HostMemorySpace>               view_i64_1d_t;
+  typedef Kokkos::View<flcl_view_r32_c_t*,Kokkos::LayoutLeft,flcl::HostMemorySpace>               view_r32_1d_t;
+  typedef Kokkos::View<flcl_view_r64_c_t*,Kokkos::LayoutLeft,flcl::HostMemorySpace>               view_r64_1d_t;
 
   // 2D fortran-compatible view types
-  typedef Kokkos::View<bool**,Kokkos::LayoutLeft,flcl::HostMemorySpace>             view_l_2d_t;
-  typedef Kokkos::View<int32_t**,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_i32_2d_t;
-  typedef Kokkos::View<int64_t**,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_i64_2d_t;
-  typedef Kokkos::View<float**,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_r32_2d_t;
-  typedef Kokkos::View<double**,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_r64_2d_t;
+  typedef Kokkos::View<flcl_view_l_c_t**,Kokkos::LayoutLeft,flcl::HostMemorySpace>                view_l_2d_t;
+  typedef Kokkos::View<flcl_view_i32_c_t**,Kokkos::LayoutLeft,flcl::HostMemorySpace>              view_i32_2d_t;
+  typedef Kokkos::View<flcl_view_i64_c_t**,Kokkos::LayoutLeft,flcl::HostMemorySpace>              view_i64_2d_t;
+  typedef Kokkos::View<flcl_view_r32_c_t**,Kokkos::LayoutLeft,flcl::HostMemorySpace>              view_r32_2d_t;
+  typedef Kokkos::View<flcl_view_r64_c_t**,Kokkos::LayoutLeft,flcl::HostMemorySpace>              view_r64_2d_t;
 
   // 3D fortran-compatible view types
-  typedef Kokkos::View<bool***,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_l_3d_t;
-  typedef Kokkos::View<int32_t***,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_i32_3d_t;
-  typedef Kokkos::View<int64_t***,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_i64_3d_t;
-  typedef Kokkos::View<float***,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_r32_3d_t;
-  typedef Kokkos::View<double***,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_r64_3d_t;
+  typedef Kokkos::View<flcl_view_l_c_t***,Kokkos::LayoutLeft,flcl::HostMemorySpace>               view_l_3d_t;
+  typedef Kokkos::View<flcl_view_i32_c_t***,Kokkos::LayoutLeft,flcl::HostMemorySpace>             view_i32_3d_t;
+  typedef Kokkos::View<flcl_view_i64_c_t***,Kokkos::LayoutLeft,flcl::HostMemorySpace>             view_i64_3d_t;
+  typedef Kokkos::View<flcl_view_r32_c_t***,Kokkos::LayoutLeft,flcl::HostMemorySpace>             view_r32_3d_t;
+  typedef Kokkos::View<flcl_view_r64_c_t***,Kokkos::LayoutLeft,flcl::HostMemorySpace>             view_r64_3d_t;
 
   // 4D fortran-compatible view types
-  typedef Kokkos::View<bool****,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_l_4d_t;
-  typedef Kokkos::View<int32_t****,Kokkos::LayoutLeft,flcl::HostMemorySpace>        view_i32_4d_t;
-  typedef Kokkos::View<int64_t****,Kokkos::LayoutLeft,flcl::HostMemorySpace>        view_i64_4d_t;
-  typedef Kokkos::View<float****,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_r32_4d_t;
-  typedef Kokkos::View<double****,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_r64_4d_t;
+  typedef Kokkos::View<flcl_view_l_c_t****,Kokkos::LayoutLeft,flcl::HostMemorySpace>              view_l_4d_t;
+  typedef Kokkos::View<flcl_view_i32_c_t****,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_i32_4d_t;
+  typedef Kokkos::View<flcl_view_i64_c_t****,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_i64_4d_t;
+  typedef Kokkos::View<flcl_view_r32_c_t****,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_r32_4d_t;
+  typedef Kokkos::View<flcl_view_r64_c_t****,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_r64_4d_t;
 
   // 5D fortran-compatible view types
-  typedef Kokkos::View<bool*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_l_5d_t;
-  typedef Kokkos::View<int32_t*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>       view_i32_5d_t;
-  typedef Kokkos::View<int64_t*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>       view_i64_5d_t;
-  typedef Kokkos::View<float*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_r32_5d_t;
-  typedef Kokkos::View<double*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>        view_r64_5d_t;
+  typedef Kokkos::View<flcl_view_l_c_t*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>             view_l_5d_t;
+  typedef Kokkos::View<flcl_view_i32_c_t*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_i32_5d_t;
+  typedef Kokkos::View<flcl_view_i64_c_t*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_i64_5d_t;
+  typedef Kokkos::View<flcl_view_r32_c_t*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_r32_5d_t;
+  typedef Kokkos::View<flcl_view_r64_c_t*****,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_r64_5d_t;
   
   // 6D fortran-compatible view types
-  typedef Kokkos::View<bool******,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_l_6d_t;
-  typedef Kokkos::View<int32_t******,Kokkos::LayoutLeft,flcl::HostMemorySpace>      view_i32_6d_t;
-  typedef Kokkos::View<int64_t******,Kokkos::LayoutLeft,flcl::HostMemorySpace>      view_i64_6d_t;
-  typedef Kokkos::View<float******,Kokkos::LayoutLeft,flcl::HostMemorySpace>        view_r32_6d_t;
-  typedef Kokkos::View<double******,Kokkos::LayoutLeft,flcl::HostMemorySpace>       view_r64_6d_t;
+  typedef Kokkos::View<flcl_view_l_c_t******,Kokkos::LayoutLeft,flcl::HostMemorySpace>            view_l_6d_t;
+  typedef Kokkos::View<flcl_view_i32_c_t******,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_i32_6d_t;
+  typedef Kokkos::View<flcl_view_i64_c_t******,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_i64_6d_t;
+  typedef Kokkos::View<flcl_view_r32_c_t******,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_r32_6d_t;
+  typedef Kokkos::View<flcl_view_r64_c_t******,Kokkos::LayoutLeft,flcl::HostMemorySpace>          view_r64_6d_t;
 
   // 7D fortran-compatible view types
-  typedef Kokkos::View<bool*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>        view_l_7d_t;
-  typedef Kokkos::View<int32_t*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>     view_i32_7d_t;
-  typedef Kokkos::View<int64_t*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>     view_i64_7d_t;
-  typedef Kokkos::View<float*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>       view_r32_7d_t;
-  typedef Kokkos::View<double*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>      view_r64_7d_t;
+  typedef Kokkos::View<flcl_view_l_c_t*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>           view_l_7d_t;
+  typedef Kokkos::View<flcl_view_i32_c_t*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_i32_7d_t;
+  typedef Kokkos::View<flcl_view_i64_c_t*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_i64_7d_t;
+  typedef Kokkos::View<flcl_view_r32_c_t*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_r32_7d_t;
+  typedef Kokkos::View<flcl_view_r64_c_t*******,Kokkos::LayoutLeft,flcl::HostMemorySpace>         view_r64_7d_t;
   
   // 1D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool*,Kokkos::LayoutLeft>                                dualview_l_1d_t;
-  typedef Kokkos::DualView<int32_t*,Kokkos::LayoutLeft>                             dualview_i32_1d_t;
-  typedef Kokkos::DualView<int64_t*,Kokkos::LayoutLeft>                             dualview_i64_1d_t;
-  typedef Kokkos::DualView<float*,Kokkos::LayoutLeft>                               dualview_r32_1d_t;
-  typedef Kokkos::DualView<double*,Kokkos::LayoutLeft>                              dualview_r64_1d_t;
+  typedef Kokkos::DualView<flcl_dualview_l_c_t*,Kokkos::LayoutLeft>                               dualview_l_1d_t;
+  typedef Kokkos::DualView<flcl_dualview_i32_c_t*,Kokkos::LayoutLeft>                             dualview_i32_1d_t;
+  typedef Kokkos::DualView<flcl_dualview_i64_c_t*,Kokkos::LayoutLeft>                             dualview_i64_1d_t;
+  typedef Kokkos::DualView<flcl_dualview_r32_c_t*,Kokkos::LayoutLeft>                             dualview_r32_1d_t;
+  typedef Kokkos::DualView<flcl_dualview_r64_c_t*,Kokkos::LayoutLeft>                             dualview_r64_1d_t;
 
   // 2D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool**,Kokkos::LayoutLeft>                               dualview_l_2d_t;
-  typedef Kokkos::DualView<int32_t**,Kokkos::LayoutLeft>                            dualview_i32_2d_t;
-  typedef Kokkos::DualView<int64_t**,Kokkos::LayoutLeft>                            dualview_i64_2d_t;
-  typedef Kokkos::DualView<float**,Kokkos::LayoutLeft>                              dualview_r32_2d_t;
-  typedef Kokkos::DualView<double**,Kokkos::LayoutLeft>                             dualview_r64_2d_t;
+  typedef Kokkos::DualView<flcl_dualview_l_c_t**,Kokkos::LayoutLeft>                              dualview_l_2d_t;
+  typedef Kokkos::DualView<flcl_dualview_i32_c_t**,Kokkos::LayoutLeft>                            dualview_i32_2d_t;
+  typedef Kokkos::DualView<flcl_dualview_i64_c_t**,Kokkos::LayoutLeft>                            dualview_i64_2d_t;
+  typedef Kokkos::DualView<flcl_dualview_r32_c_t**,Kokkos::LayoutLeft>                            dualview_r32_2d_t;
+  typedef Kokkos::DualView<flcl_dualview_r64_c_t**,Kokkos::LayoutLeft>                            dualview_r64_2d_t;
 
   // 3D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool***,Kokkos::LayoutLeft>                              dualview_l_3d_t;
-  typedef Kokkos::DualView<int32_t***,Kokkos::LayoutLeft>                           dualview_i32_3d_t;
-  typedef Kokkos::DualView<int64_t***,Kokkos::LayoutLeft>                           dualview_i64_3d_t;
-  typedef Kokkos::DualView<float***,Kokkos::LayoutLeft>                             dualview_r32_3d_t;
-  typedef Kokkos::DualView<double***,Kokkos::LayoutLeft>                            dualview_r64_3d_t;
+  typedef Kokkos::DualView<flcl_dualview_l_c_t***,Kokkos::LayoutLeft>                             dualview_l_3d_t;
+  typedef Kokkos::DualView<flcl_dualview_i32_c_t***,Kokkos::LayoutLeft>                           dualview_i32_3d_t;
+  typedef Kokkos::DualView<flcl_dualview_i64_c_t***,Kokkos::LayoutLeft>                           dualview_i64_3d_t;
+  typedef Kokkos::DualView<flcl_dualview_r32_c_t***,Kokkos::LayoutLeft>                           dualview_r32_3d_t;
+  typedef Kokkos::DualView<flcl_dualview_r64_c_t***,Kokkos::LayoutLeft>                           dualview_r64_3d_t;
 
   // 4D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool****,Kokkos::LayoutLeft>                             dualview_l_4d_t;
-  typedef Kokkos::DualView<int32_t****,Kokkos::LayoutLeft>                          dualview_i32_4d_t;
-  typedef Kokkos::DualView<int64_t****,Kokkos::LayoutLeft>                          dualview_i64_4d_t;
-  typedef Kokkos::DualView<float****,Kokkos::LayoutLeft>                            dualview_r32_4d_t;
-  typedef Kokkos::DualView<double****,Kokkos::LayoutLeft>                           dualview_r64_4d_t;
+  typedef Kokkos::DualView<flcl_dualview_l_c_t****,Kokkos::LayoutLeft>                            dualview_l_4d_t;
+  typedef Kokkos::DualView<flcl_dualview_i32_c_t****,Kokkos::LayoutLeft>                          dualview_i32_4d_t;
+  typedef Kokkos::DualView<flcl_dualview_i64_c_t****,Kokkos::LayoutLeft>                          dualview_i64_4d_t;
+  typedef Kokkos::DualView<flcl_dualview_r32_c_t****,Kokkos::LayoutLeft>                          dualview_r32_4d_t;
+  typedef Kokkos::DualView<flcl_dualview_r64_c_t****,Kokkos::LayoutLeft>                          dualview_r64_4d_t;
 
   // 5D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool*****,Kokkos::LayoutLeft>                            dualview_l_5d_t;
-  typedef Kokkos::DualView<int32_t*****,Kokkos::LayoutLeft>                         dualview_i32_5d_t;
-  typedef Kokkos::DualView<int64_t*****,Kokkos::LayoutLeft>                         dualview_i64_5d_t;
-  typedef Kokkos::DualView<float*****,Kokkos::LayoutLeft>                           dualview_r32_5d_t;
-  typedef Kokkos::DualView<double*****,Kokkos::LayoutLeft>                          dualview_r64_5d_t;
+  typedef Kokkos::DualView<flcl_dualview_l_c_t*****,Kokkos::LayoutLeft>                           dualview_l_5d_t;
+  typedef Kokkos::DualView<flcl_dualview_i32_c_t*****,Kokkos::LayoutLeft>                         dualview_i32_5d_t;
+  typedef Kokkos::DualView<flcl_dualview_i64_c_t*****,Kokkos::LayoutLeft>                         dualview_i64_5d_t;
+  typedef Kokkos::DualView<flcl_dualview_r32_c_t*****,Kokkos::LayoutLeft>                         dualview_r32_5d_t;
+  typedef Kokkos::DualView<flcl_dualview_r64_c_t*****,Kokkos::LayoutLeft>                         dualview_r64_5d_t;
 
   // 6D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool******,Kokkos::LayoutLeft>                           dualview_l_6d_t;
-  typedef Kokkos::DualView<int32_t******,Kokkos::LayoutLeft>                        dualview_i32_6d_t;
-  typedef Kokkos::DualView<int64_t******,Kokkos::LayoutLeft>                        dualview_i64_6d_t;
-  typedef Kokkos::DualView<float******,Kokkos::LayoutLeft>                          dualview_r32_6d_t;
-  typedef Kokkos::DualView<double******,Kokkos::LayoutLeft>                         dualview_r64_6d_t;
+  typedef Kokkos::DualView<flcl_dualview_l_c_t******,Kokkos::LayoutLeft>                          dualview_l_6d_t;
+  typedef Kokkos::DualView<flcl_dualview_i32_c_t******,Kokkos::LayoutLeft>                        dualview_i32_6d_t;
+  typedef Kokkos::DualView<flcl_dualview_i64_c_t******,Kokkos::LayoutLeft>                        dualview_i64_6d_t;
+  typedef Kokkos::DualView<flcl_dualview_r32_c_t******,Kokkos::LayoutLeft>                        dualview_r32_6d_t;
+  typedef Kokkos::DualView<flcl_dualview_r64_c_t******,Kokkos::LayoutLeft>                        dualview_r64_6d_t;
 
   // 7D fortran-compatible dualview types
-  typedef Kokkos::DualView<bool*******,Kokkos::LayoutLeft>                          dualview_l_7d_t;
-  typedef Kokkos::DualView<int32_t*******,Kokkos::LayoutLeft>                       dualview_i32_7d_t;
-  typedef Kokkos::DualView<int64_t*******,Kokkos::LayoutLeft>                       dualview_i64_7d_t;
-  typedef Kokkos::DualView<float*******,Kokkos::LayoutLeft>                         dualview_r32_7d_t;
-  typedef Kokkos::DualView<double*******,Kokkos::LayoutLeft>                        dualview_r64_7d_t;
+  typedef Kokkos::DualView<flcl_dualview_l_c_t*******,Kokkos::LayoutLeft>                         dualview_l_7d_t;
+  typedef Kokkos::DualView<flcl_dualview_i32_c_t*******,Kokkos::LayoutLeft>                       dualview_i32_7d_t;
+  typedef Kokkos::DualView<flcl_dualview_i64_c_t*******,Kokkos::LayoutLeft>                       dualview_i64_7d_t;
+  typedef Kokkos::DualView<flcl_dualview_r32_c_t*******,Kokkos::LayoutLeft>                       dualview_r32_7d_t;
+  typedef Kokkos::DualView<flcl_dualview_r64_c_t*******,Kokkos::LayoutLeft>                       dualview_r64_7d_t;
 
   template <typename DataType>
   Kokkos::View<DataType, Kokkos::LayoutStride, flcl::HostMemorySpace>

--- a/src/flcl-dualview-f.f90
+++ b/src/flcl-dualview-f.f90
@@ -39,7 +39,8 @@ module flcl_dualview_mod
   use, intrinsic :: iso_c_binding
   use, intrinsic :: iso_fortran_env
   use flcl_util_strings_mod, only: char_add_null
-  
+  use flcl_types_f_mod
+
   implicit none
   private
   
@@ -452,11 +453,12 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_l_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_dv_l_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0      
+      integer(flcl_dualview_index_f_t), intent(in) :: e0      
     end subroutine f_kokkos_allocate_dv_l_1d
   end interface
 
@@ -464,11 +466,12 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i32_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_dv_i32_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_dv_i32_1d
   end interface
   
@@ -476,11 +479,12 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i64_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_dv_i64_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_dv_i64_1d
   end interface
 
@@ -488,11 +492,12 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r32_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_dv_r32_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_dv_r32_1d
   end interface
   
@@ -500,11 +505,12 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r64_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_dv_r64_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_dv_r64_1d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -514,12 +520,13 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_l_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_dv_l_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_dv_l_2d
   end interface
   
@@ -527,12 +534,13 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i32_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_dv_i32_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_dv_i32_2d
   end interface
 
@@ -540,12 +548,13 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i64_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_dv_i64_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_dv_i64_2d
   end interface
   
@@ -553,12 +562,13 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r32_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_dv_r32_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_dv_r32_2d
   end interface
 
@@ -566,12 +576,13 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r64_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_dv_r64_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_dv_r64_2d
   end interface  
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -581,13 +592,14 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_l_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_dv_l_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_dv_l_3d
   end interface
 
@@ -595,13 +607,14 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i32_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_dv_i32_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_dv_i32_3d
   end interface
   
@@ -609,13 +622,14 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i64_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_dv_i64_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_dv_i64_3d
   end interface
 
@@ -623,13 +637,14 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r32_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_dv_r32_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_dv_r32_3d
   end interface
   
@@ -637,13 +652,14 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r64_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_dv_r64_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_dv_r64_3d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -653,14 +669,15 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_l_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_dv_l_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_dv_l_4d
   end interface
 
@@ -668,14 +685,15 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i32_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_dv_i32_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_dv_i32_4d
   end interface
   
@@ -683,14 +701,15 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i64_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_dv_i64_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_dv_i64_4d
   end interface
 
@@ -698,14 +717,15 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r32_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_dv_r32_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_dv_r32_4d
   end interface
   
@@ -713,14 +733,15 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r64_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_dv_r64_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_dv_r64_4d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -730,15 +751,16 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_l_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_dv_l_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_dv_l_5d
   end interface
 
@@ -746,15 +768,16 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i32_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_dv_i32_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_dv_i32_5d
   end interface
   
@@ -762,15 +785,16 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i64_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_dv_i64_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_dv_i64_5d
   end interface
 
@@ -778,15 +802,16 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r32_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_dv_r32_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_dv_r32_5d
   end interface
   
@@ -794,15 +819,16 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r64_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_dv_r64_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_dv_r64_5d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -812,16 +838,17 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_l_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_dv_l_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_dv_l_6d
   end interface
 
@@ -829,16 +856,17 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i32_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_dv_i32_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_dv_i32_6d
   end interface
   
@@ -846,16 +874,17 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i64_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_dv_i64_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_dv_i64_6d
   end interface
 
@@ -863,16 +892,17 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r32_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_dv_r32_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_dv_r32_6d
   end interface
   
@@ -880,16 +910,17 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r64_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_dv_r64_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_dv_r64_6d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -899,17 +930,18 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_l_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_dv_l_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_dv_l_7d
   end interface
 
@@ -917,17 +949,18 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i32_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_dv_i32_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_dv_i32_7d
   end interface
   
@@ -935,17 +968,18 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_i64_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_dv_i64_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_dv_i64_7d
   end interface
 
@@ -953,17 +987,18 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r32_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_dv_r32_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_dv_r32_7d
   end interface
   
@@ -971,17 +1006,18 @@ module flcl_dualview_mod
     subroutine f_kokkos_allocate_dv_r64_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_dv_r64_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_dv_r64_7d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1324,10 +1360,10 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:), intent(inout) :: A
+      logical(flcl_dualview_l_f_t), pointer, dimension(:), intent(inout) :: A
       type(dualview_l_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
       
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1341,10 +1377,10 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer (INT32), pointer, dimension(:), intent(inout) :: A
+      integer (flcl_dualview_i32_f_t), pointer, dimension(:), intent(inout) :: A
       type(dualview_i32_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
       
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1358,10 +1394,10 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:), intent(inout) :: A
+      integer(flcl_dualview_i64_f_t), pointer, dimension(:), intent(inout) :: A
       type(dualview_i64_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
       
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1375,10 +1411,10 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:), intent(inout) :: A
+      real(flcl_dualview_r32_f_t), pointer, dimension(:), intent(inout) :: A
       type(dualview_r32_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1392,10 +1428,10 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:), intent(inout) :: A
+      real(flcl_dualview_r64_f_t), pointer, dimension(:), intent(inout) :: A
       type(dualview_r64_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1411,11 +1447,11 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:), intent(inout) :: A
+      logical(flcl_dualview_l_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(dualview_l_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1429,11 +1465,11 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:), intent(inout) :: A
+      integer(flcl_dualview_i32_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(dualview_i32_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1447,11 +1483,11 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer (INT64), pointer, dimension(:,:), intent(inout) :: A
+      integer (flcl_dualview_i64_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(dualview_i64_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1465,11 +1501,11 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:), intent(inout) :: A
+      real(flcl_dualview_r32_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(dualview_r32_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1483,11 +1519,11 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:), intent(inout) :: A
+      real(flcl_dualview_r64_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(dualview_r64_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1503,12 +1539,12 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:), intent(inout) :: A
+      logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(dualview_l_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1522,12 +1558,12 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(dualview_i32_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1541,12 +1577,12 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(dualview_i64_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1560,12 +1596,12 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:), intent(inout) :: A
+      real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(dualview_r32_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1579,12 +1615,12 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:), intent(inout) :: A
+      real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(dualview_r64_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1600,13 +1636,13 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:), intent(inout) :: A
+      logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(dualview_l_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1620,13 +1656,13 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(dualview_i32_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1640,13 +1676,13 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(dualview_i64_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1660,13 +1696,13 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(dualview_r32_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1680,13 +1716,13 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(dualview_r64_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1702,14 +1738,14 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(dualview_l_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1723,14 +1759,14 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(dualview_i32_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1744,14 +1780,14 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(dualview_i64_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1765,14 +1801,14 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(dualview_r32_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1786,14 +1822,14 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(dualview_r64_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1809,15 +1845,15 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(dualview_l_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1831,15 +1867,15 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(dualview_i32_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1853,15 +1889,15 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(dualview_i64_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1875,15 +1911,15 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(dualview_r32_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1897,15 +1933,15 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(dualview_r64_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1921,16 +1957,16 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(dualview_l_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1944,16 +1980,16 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(dualview_i32_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1967,16 +2003,16 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(dualview_i64_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1990,16 +2026,16 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(dualview_r32_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -2013,16 +2049,16 @@ module flcl_dualview_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(dualview_r64_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_dualview_index_f_t), intent(in) :: e0
+      integer(flcl_dualview_index_f_t), intent(in) :: e1
+      integer(flcl_dualview_index_f_t), intent(in) :: e2
+      integer(flcl_dualview_index_f_t), intent(in) :: e3
+      integer(flcl_dualview_index_f_t), intent(in) :: e4
+      integer(flcl_dualview_index_f_t), intent(in) :: e5
+      integer(flcl_dualview_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -2037,7 +2073,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_l_1d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    logical(c_bool), pointer, dimension(:), intent(inout) :: A
+    logical(flcl_dualview_l_f_t), pointer, dimension(:), intent(inout) :: A
     type(dualview_l_1d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2049,7 +2085,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i32_1d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT32), pointer, dimension(:), intent(inout) :: A
+    integer(flcl_dualview_i32_f_t), pointer, dimension(:), intent(inout) :: A
     type(dualview_i32_1d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2061,7 +2097,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i64_1d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT64), pointer, dimension(:), intent(inout) :: A
+    integer(flcl_dualview_i64_f_t), pointer, dimension(:), intent(inout) :: A
     type(dualview_i64_1d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2073,7 +2109,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r32_1d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL32), pointer, dimension(:), intent(inout) :: A
+    real(flcl_dualview_r32_f_t), pointer, dimension(:), intent(inout) :: A
     type(dualview_r32_1d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2085,7 +2121,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r64_1d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL64), pointer, dimension(:), intent(inout) :: A
+    real(flcl_dualview_r64_f_t), pointer, dimension(:), intent(inout) :: A
     type(dualview_r64_1d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2101,7 +2137,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_l_2d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    logical(c_bool), pointer, dimension(:,:), intent(inout) :: A
+    logical(flcl_dualview_l_f_t), pointer, dimension(:,:), intent(inout) :: A
     type(dualview_l_2d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2113,7 +2149,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i32_2d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT32), pointer, dimension(:,:), intent(inout) :: A
+    integer(flcl_dualview_i32_f_t), pointer, dimension(:,:), intent(inout) :: A
     type(dualview_i32_2d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2125,7 +2161,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i64_2d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT64), pointer, dimension(:,:), intent(inout) :: A
+    integer(flcl_dualview_i64_f_t), pointer, dimension(:,:), intent(inout) :: A
     type(dualview_i64_2d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2137,7 +2173,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r32_2d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL32), pointer, dimension(:,:), intent(inout) :: A
+    real(flcl_dualview_r32_f_t), pointer, dimension(:,:), intent(inout) :: A
     type(dualview_r32_2d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2149,7 +2185,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r64_2d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL64), pointer, dimension(:,:), intent(inout) :: A
+    real(flcl_dualview_r64_f_t), pointer, dimension(:,:), intent(inout) :: A
     type(dualview_r64_2d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2163,7 +2199,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_l_3d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    logical(c_bool), pointer, dimension(:,:,:), intent(inout) :: A
+    logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:), intent(inout) :: A
     type(dualview_l_3d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2175,7 +2211,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i32_3d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT32), pointer, dimension(:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
     type(dualview_i32_3d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2187,7 +2223,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i64_3d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT64), pointer, dimension(:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
     type(dualview_i64_3d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2199,7 +2235,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r32_3d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL32), pointer, dimension(:,:,:), intent(inout) :: A
+    real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
     type(dualview_r32_3d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2211,7 +2247,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r64_3d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL64), pointer, dimension(:,:,:), intent(inout) :: A
+    real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
     type(dualview_r64_3d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2225,7 +2261,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_l_4d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    logical(c_bool), pointer, dimension(:,:,:,:), intent(inout) :: A
+    logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
     type(dualview_l_4d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2237,7 +2273,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i32_4d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT32), pointer, dimension(:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
     type(dualview_i32_4d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2249,7 +2285,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i64_4d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT64), pointer, dimension(:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
     type(dualview_i64_4d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2261,7 +2297,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r32_4d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL32), pointer, dimension(:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
     type(dualview_r32_4d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2273,7 +2309,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r64_4d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL64), pointer, dimension(:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
     type(dualview_r64_4d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2287,7 +2323,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_l_5d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    logical(c_bool), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
     type(dualview_l_5d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2299,7 +2335,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i32_5d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
     type(dualview_i32_5d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2311,7 +2347,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i64_5d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
     type(dualview_i64_5d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2323,7 +2359,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r32_5d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
     type(dualview_r32_5d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2335,7 +2371,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r64_5d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
     type(dualview_r64_5d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2349,7 +2385,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_l_6d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    logical(c_bool), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
     type(dualview_l_6d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2361,7 +2397,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i32_6d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
     type(dualview_i32_6d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2373,7 +2409,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i64_6d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
     type(dualview_i64_6d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2385,7 +2421,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r32_6d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
     type(dualview_r32_6d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2397,7 +2433,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r64_6d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
     type(dualview_r64_6d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2411,7 +2447,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_l_7d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    logical(c_bool), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
     type(dualview_l_7d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2423,7 +2459,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i32_7d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
     type(dualview_i32_7d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2435,7 +2471,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_i64_7d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    integer(INT64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
     type(dualview_i64_7d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2447,7 +2483,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r32_7d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
     type(dualview_r32_7d_t), intent(inout) :: v_A
 
     A => NULL()
@@ -2459,7 +2495,7 @@ module flcl_dualview_mod
   subroutine kokkos_deallocate_dv_r64_7d(A, v_A )
     use, intrinsic :: iso_c_binding
     implicit none
-    real(REAL64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+    real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
     type(dualview_r64_7d_t), intent(inout) :: v_A
 
     A => NULL()

--- a/src/flcl-f.f90
+++ b/src/flcl-f.f90
@@ -41,6 +41,7 @@ module flcl_mod
   use flcl_ndarray_mod
   use flcl_view_mod
   use flcl_dualview_mod
+  use flcl_types_f_mod
   
   implicit none
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/flcl-ndarray-f.f90
+++ b/src/flcl-ndarray-f.f90
@@ -38,7 +38,8 @@
 module flcl_ndarray_mod
     use, intrinsic :: iso_c_binding
     use, intrinsic :: iso_fortran_env
-    
+    use flcl_types_f_mod
+
     implicit none
     private
     
@@ -49,9 +50,9 @@ module flcl_ndarray_mod
     integer, parameter :: ND_ARRAY_MAX_RANK = 8
     
     type, bind(C) :: nd_array_t
-      integer(c_size_t) :: rank
-      integer(c_size_t) :: dims(ND_ARRAY_MAX_RANK)
-      integer(c_size_t) :: strides(ND_ARRAY_MAX_RANK)
+      integer(flcl_ndarray_index_f_t) :: rank
+      integer(flcl_ndarray_index_f_t) :: dims(ND_ARRAY_MAX_RANK)
+      integer(flcl_ndarray_index_f_t) :: strides(ND_ARRAY_MAX_RANK)
       type(c_ptr) :: data
     end type nd_array_t
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -129,11 +130,11 @@ module flcl_ndarray_mod
   !!! to_nd_array 1D implementations
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       function to_nd_array_l_1d(array) result(ndarray)
-        logical(c_bool), target, intent(in) :: array(:)
+        logical(flcl_ndarray_l_f_t), target, intent(in) :: array(:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
         ndarray%rank = 1
   
         if (size(array) .eq. 0) then
@@ -142,8 +143,8 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2)), 1_c_size_t) - &
-                transfer(c_loc(array(1)), 1_c_size_t)) / c_sizeof(array(1))
+              (transfer(c_loc(array(2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1))
           else
             ndarray%strides(1) = 1
           end if
@@ -153,11 +154,11 @@ module flcl_ndarray_mod
       end function to_nd_array_l_1d
       
       function to_nd_array_i32_1d(array) result(ndarray)
-        integer(INT32), target, intent(in) :: array(:)
+        integer(flcl_ndarray_i32_f_t), target, intent(in) :: array(:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
         ndarray%rank = 1
         
         if (size(array) .eq. 0) then
@@ -166,8 +167,8 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2)), 1_c_size_t) - &
-                transfer(c_loc(array(1)), 1_c_size_t)) / c_sizeof(array(1))
+              (transfer(c_loc(array(2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1))
           else
             ndarray%strides(1) = 1
           end if
@@ -177,11 +178,11 @@ module flcl_ndarray_mod
       end function to_nd_array_i32_1d
       
       function to_nd_array_i64_1d(array) result(ndarray)
-        integer(INT64), target, intent(in) :: array(:)
+        integer(flcl_ndarray_i64_f_t), target, intent(in) :: array(:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
         ndarray%rank = 1
 
         if (size(array) .eq. 0) then
@@ -190,8 +191,8 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2)), 1_c_size_t) - &
-                transfer(c_loc(array(1)), 1_c_size_t)) / c_sizeof(array(1))
+              (transfer(c_loc(array(2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1))
           else
             ndarray%strides(1) = 1
           end if
@@ -201,11 +202,11 @@ module flcl_ndarray_mod
       end function to_nd_array_i64_1d
       
       function to_nd_array_r32_1d(array) result(ndarray)
-        real(REAL32), target, intent(in) :: array(:)
+        real(flcl_ndarray_r32_f_t), target, intent(in) :: array(:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
         ndarray%rank = 1
   
         if (size(array) .eq. 0) then
@@ -214,8 +215,8 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2)), 1_c_size_t) - &
-                transfer(c_loc(array(1)), 1_c_size_t)) / c_sizeof(array(1))
+              (transfer(c_loc(array(2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1))
           else
             ndarray%strides(1) = 1
           end if
@@ -225,11 +226,11 @@ module flcl_ndarray_mod
       end function to_nd_array_r32_1d
       
       function to_nd_array_r64_1d(array) result(ndarray)
-        real(REAL64), target, intent(in) :: array(:)
+        real(flcl_ndarray_r64_f_t), target, intent(in) :: array(:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
         ndarray%rank = 1
   
         if (size(array) .eq. 0) then
@@ -238,8 +239,8 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2)), 1_c_size_t) - &
-                transfer(c_loc(array(1)), 1_c_size_t)) / c_sizeof(array(1))
+              (transfer(c_loc(array(2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1))
           else
             ndarray%strides(1) = 1
           end if
@@ -249,11 +250,11 @@ module flcl_ndarray_mod
       end function to_nd_array_r64_1d
   
       function to_nd_array_c32_1d(array) result(ndarray)
-        complex(c_float_complex), target, intent(in) :: array(:)
+        complex(flcl_ndarray_c32_f_t), target, intent(in) :: array(:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
         ndarray%rank = 1
 
         if (size(array) .eq. 0) then
@@ -262,8 +263,8 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-                (transfer(c_loc(array(2)), 1_c_size_t) - &
-                transfer(c_loc(array(1)), 1_c_size_t)) / c_sizeof(array(1))
+                (transfer(c_loc(array(2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1))
           else
             ndarray%strides(1) = 1
           end if
@@ -273,11 +274,11 @@ module flcl_ndarray_mod
       end function to_nd_array_c32_1d
   
       function to_nd_array_c64_1d(array) result(ndarray)
-        complex(c_double_complex), target, intent(in) :: array(:)
+        complex(flcl_ndarray_c64_f_t), target, intent(in) :: array(:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
         ndarray%rank = 1
 
         if (size(array) .eq. 0) then
@@ -286,8 +287,8 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-                (transfer(c_loc(array(2)), 1_c_size_t) - &
-                transfer(c_loc(array(1)), 1_c_size_t)) / c_sizeof(array(1))
+                (transfer(c_loc(array(2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1))
           else
             ndarray%strides(1) = 1
           end if
@@ -299,12 +300,12 @@ module flcl_ndarray_mod
   !!! to_nd_array 2D implementations
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       function to_nd_array_l_2d(array) result(ndarray)
-        logical(c_bool), target, intent(in) :: array(:,:)
+        logical(flcl_ndarray_l_f_t), target, intent(in) :: array(:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
         ndarray%rank = 2
 
         if (size(array) .eq. 0) then
@@ -313,16 +314,16 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(2) = size(array, 1)
           end if
@@ -332,12 +333,12 @@ module flcl_ndarray_mod
       end function to_nd_array_l_2d
       
       function to_nd_array_i32_2d(array) result(ndarray)
-        integer(INT32), target, intent(in) :: array(:,:)
+        integer(flcl_ndarray_i32_f_t), target, intent(in) :: array(:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
         ndarray%rank = 2
 
         if (size(array) .eq. 0) then
@@ -346,16 +347,16 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(2) = size(array, 1)
           end if
@@ -365,12 +366,12 @@ module flcl_ndarray_mod
       end function to_nd_array_i32_2d
       
       function to_nd_array_i64_2d(array) result(ndarray)
-        integer(INT64), target, intent(in) :: array(:,:)
+        integer(flcl_ndarray_i64_f_t), target, intent(in) :: array(:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
         ndarray%rank = 2
 
         if (size(array) .eq. 0) then
@@ -379,16 +380,16 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(2) = size(array, 1)
           end if
@@ -398,12 +399,12 @@ module flcl_ndarray_mod
       end function to_nd_array_i64_2d
       
       function to_nd_array_r32_2d(array) result(ndarray)
-        real(REAL32), target, intent(in) :: array(:,:)
+        real(flcl_ndarray_r32_f_t), target, intent(in) :: array(:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
         ndarray%rank = 2
 
         if (size(array) .eq. 0) then
@@ -412,16 +413,16 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(2) = size(array, 1)
           end if
@@ -431,12 +432,12 @@ module flcl_ndarray_mod
       end function to_nd_array_r32_2d
       
       function to_nd_array_r64_2d(array) result(ndarray)
-        real(REAL64), target, intent(in) :: array(:,:)
+        real(flcl_ndarray_r64_f_t), target, intent(in) :: array(:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
         ndarray%rank = 2
 
         if (size(array) .eq. 0) then
@@ -445,16 +446,16 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(2) = size(array, 1)
           end if
@@ -464,12 +465,12 @@ module flcl_ndarray_mod
       end function to_nd_array_r64_2d
   
       function to_nd_array_c32_2d(array) result(ndarray)
-        complex(c_float_complex), target, intent(in) :: array(:,:)
+        complex(flcl_ndarray_c32_f_t), target, intent(in) :: array(:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
         ndarray%rank = 2
 
         if (size(array) .eq. 0) then
@@ -478,16 +479,16 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(2) = size(array, 1)
           end if
@@ -497,12 +498,12 @@ module flcl_ndarray_mod
       end function to_nd_array_c32_2d
   
       function to_nd_array_c64_2d(array) result(ndarray)
-        complex(c_double_complex), target, intent(in) :: array(:,:)
+        complex(flcl_ndarray_c64_f_t), target, intent(in) :: array(:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
         ndarray%rank = 2
 
         if (size(array) .eq. 0) then
@@ -511,16 +512,16 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1)), 1_c_size_t)) / c_sizeof(array(1,1))
+              (transfer(c_loc(array(1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1))
           else
             ndarray%strides(2) = size(array, 1)
           end if
@@ -532,13 +533,13 @@ module flcl_ndarray_mod
   !!! to_nd_array 3D implementations
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       function to_nd_array_l_3d(array) result(ndarray)
-        logical(c_bool), target, intent(in) :: array(:,:,:)
+        logical(flcl_ndarray_l_f_t), target, intent(in) :: array(:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
         ndarray%rank = 3
 
         if (size(array) .eq. 0) then
@@ -547,26 +548,26 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           ndarray%data = c_loc(array(1,1,1))
@@ -574,13 +575,13 @@ module flcl_ndarray_mod
       end function to_nd_array_l_3d
       
       function to_nd_array_i32_3d(array) result(ndarray)
-        integer(INT32), target, intent(in) :: array(:,:,:)
+        integer(flcl_ndarray_i32_f_t), target, intent(in) :: array(:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
         ndarray%rank = 3
 
         if (size(array) .eq. 0) then
@@ -589,26 +590,26 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           ndarray%data = c_loc(array(1,1,1))
@@ -616,13 +617,13 @@ module flcl_ndarray_mod
       end function to_nd_array_i32_3d
       
       function to_nd_array_i64_3d(array) result(ndarray)
-        integer(INT64), target, intent(in) :: array(:,:,:)
+        integer(flcl_ndarray_i64_f_t), target, intent(in) :: array(:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
         ndarray%rank = 3
 
         if (size(array) .eq. 0) then
@@ -631,26 +632,26 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           ndarray%data = c_loc(array(1,1,1))
@@ -658,13 +659,13 @@ module flcl_ndarray_mod
       end function to_nd_array_i64_3d
       
       function to_nd_array_r32_3d(array) result(ndarray)
-        real(REAL32), target, intent(in) :: array(:,:,:)
+        real(flcl_ndarray_r32_f_t), target, intent(in) :: array(:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
         ndarray%rank = 3
 
         if (size(array) .eq. 0) then
@@ -673,26 +674,26 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
             
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           ndarray%data = c_loc(array(1,1,1))
@@ -700,13 +701,13 @@ module flcl_ndarray_mod
       end function to_nd_array_r32_3d
       
       function to_nd_array_r64_3d(array) result(ndarray)
-        real(REAL64), target, intent(in) :: array(:,:,:)
+        real(flcl_ndarray_r64_f_t), target, intent(in) :: array(:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
         ndarray%rank = 3
 
         if (size(array) .eq. 0) then
@@ -715,26 +716,26 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           ndarray%data = c_loc(array(1,1,1))
@@ -742,13 +743,13 @@ module flcl_ndarray_mod
       end function to_nd_array_r64_3d
   
       function to_nd_array_c32_3d(array) result(ndarray)
-        complex(c_float_complex), target, intent(in) :: array(:,:,:)
+        complex(flcl_ndarray_c32_f_t), target, intent(in) :: array(:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
         ndarray%rank = 3
 
         if (size(array) .eq. 0) then
@@ -757,26 +758,26 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           ndarray%data = c_loc(array(1,1,1))
@@ -784,13 +785,13 @@ module flcl_ndarray_mod
       end function to_nd_array_c32_3d
   
       function to_nd_array_c64_3d(array) result(ndarray)
-        complex(c_double_complex), target, intent(in) :: array(:,:,:)
+        complex(flcl_ndarray_c64_f_t), target, intent(in) :: array(:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
         ndarray%rank = 3
 
         if (size(array) .eq. 0) then
@@ -799,26 +800,26 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1))
+              (transfer(c_loc(array(1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           ndarray%data = c_loc(array(1,1,1))
@@ -828,14 +829,14 @@ module flcl_ndarray_mod
   !!! to_nd_array 4D implementations
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       function to_nd_array_l_4d(array) result(ndarray)
-        logical(c_bool), target, intent(in) :: array(:,:,:,:)
+        logical(flcl_ndarray_l_f_t), target, intent(in) :: array(:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
         ndarray%rank = 4
 
         if (size(array) .eq. 0) then
@@ -844,34 +845,34 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1))
@@ -879,14 +880,14 @@ module flcl_ndarray_mod
       end function to_nd_array_l_4d
     
       function to_nd_array_i32_4d(array) result(ndarray)
-        integer(INT32), target, intent(in) :: array(:,:,:,:)
+        integer(flcl_ndarray_i32_f_t), target, intent(in) :: array(:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
         ndarray%rank = 4
 
         if (size(array) .eq. 0) then
@@ -895,34 +896,34 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1))
@@ -930,14 +931,14 @@ module flcl_ndarray_mod
       end function to_nd_array_i32_4d
     
       function to_nd_array_i64_4d(array) result(ndarray)
-        integer(INT64), target, intent(in) :: array(:,:,:,:)
+        integer(flcl_ndarray_i64_f_t), target, intent(in) :: array(:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
         ndarray%rank = 4
 
         if (size(array) .eq. 0) then
@@ -946,34 +947,34 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1))
@@ -981,14 +982,14 @@ module flcl_ndarray_mod
       end function to_nd_array_i64_4d
     
       function to_nd_array_r32_4d(array) result(ndarray)
-        real(REAL32), target, intent(in) :: array(:,:,:,:)
+        real(flcl_ndarray_r32_f_t), target, intent(in) :: array(:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
         ndarray%rank = 4
 
         if (size(array) .eq. 0) then
@@ -997,34 +998,34 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1))
@@ -1032,14 +1033,14 @@ module flcl_ndarray_mod
       end function to_nd_array_r32_4d
     
       function to_nd_array_r64_4d(array) result(ndarray)
-        real(REAL64), target, intent(in) :: array(:,:,:,:)
+        real(flcl_ndarray_r64_f_t), target, intent(in) :: array(:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
         ndarray%rank = 4
 
         if (size(array) .eq. 0) then
@@ -1048,34 +1049,34 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1))
@@ -1083,14 +1084,14 @@ module flcl_ndarray_mod
       end function to_nd_array_r64_4d
   
       function to_nd_array_c32_4d(array) result(ndarray)
-        complex(c_float_complex), target, intent(in) :: array(:,:,:,:)
+        complex(flcl_ndarray_c32_f_t), target, intent(in) :: array(:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
         ndarray%rank = 4
 
         if (size(array) .eq. 0) then
@@ -1099,34 +1100,34 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1))
@@ -1134,14 +1135,14 @@ module flcl_ndarray_mod
       end function to_nd_array_c32_4d
   
       function to_nd_array_c64_4d(array) result(ndarray)
-        complex(c_double_complex), target, intent(in) :: array(:,:,:,:)
+        complex(flcl_ndarray_c64_f_t), target, intent(in) :: array(:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
         ndarray%rank = 4
 
         if (size(array) .eq. 0) then
@@ -1150,34 +1151,34 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1))
@@ -1187,15 +1188,15 @@ module flcl_ndarray_mod
   !!! to_nd_array 5D implementations
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       function to_nd_array_l_5d(array) result(ndarray)
-        logical(c_bool), target, intent(in) :: array(:,:,:,:,:)
+        logical(flcl_ndarray_l_f_t), target, intent(in) :: array(:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
         ndarray%rank = 5
 
         if (size(array) .eq. 0) then
@@ -1204,42 +1205,42 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1))
@@ -1247,15 +1248,15 @@ module flcl_ndarray_mod
       end function to_nd_array_l_5d
   
       function to_nd_array_i32_5d(array) result(ndarray)
-        integer(INT32), target, intent(in) :: array(:,:,:,:,:)
+        integer(flcl_ndarray_i32_f_t), target, intent(in) :: array(:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
         ndarray%rank = 5
 
         if (size(array) .eq. 0) then
@@ -1264,42 +1265,42 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1))
@@ -1307,15 +1308,15 @@ module flcl_ndarray_mod
       end function to_nd_array_i32_5d
   
       function to_nd_array_i64_5d(array) result(ndarray)
-        integer(INT64), target, intent(in) :: array(:,:,:,:,:)
+        integer(flcl_ndarray_i64_f_t), target, intent(in) :: array(:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
         ndarray%rank = 5
 
         if (size(array) .eq. 0) then
@@ -1324,42 +1325,42 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2)), 1_c_size_t) - &
-                transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+                transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1))
@@ -1367,15 +1368,15 @@ module flcl_ndarray_mod
       end function to_nd_array_i64_5d
   
       function to_nd_array_r32_5d(array) result(ndarray)
-        real(REAL32), target, intent(in) :: array(:,:,:,:,:)
+        real(flcl_ndarray_r32_f_t), target, intent(in) :: array(:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
         ndarray%rank = 5
 
         if (size(array) .eq. 0) then
@@ -1384,42 +1385,42 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1))
@@ -1427,15 +1428,15 @@ module flcl_ndarray_mod
       end function to_nd_array_r32_5d
   
       function to_nd_array_r64_5d(array) result(ndarray)
-        real(REAL64), target, intent(in) :: array(:,:,:,:,:)
+        real(flcl_ndarray_r64_f_t), target, intent(in) :: array(:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
         ndarray%rank = 5
 
         if (size(array) .eq. 0) then
@@ -1444,42 +1445,42 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1))
@@ -1487,15 +1488,15 @@ module flcl_ndarray_mod
       end function to_nd_array_r64_5d
   
       function to_nd_array_c32_5d(array) result(ndarray)
-        complex(c_float_complex), target, intent(in) :: array(:,:,:,:,:)
+        complex(flcl_ndarray_c32_f_t), target, intent(in) :: array(:,:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
         ndarray%rank = 5
 
         if (size(array) .eq. 0) then
@@ -1504,42 +1505,42 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1))
@@ -1547,15 +1548,15 @@ module flcl_ndarray_mod
       end function to_nd_array_c32_5d
   
       function to_nd_array_c64_5d(array) result(ndarray)
-        complex(c_double_complex), target, intent(in) :: array(:,:,:,:,:)
+        complex(flcl_ndarray_c64_f_t), target, intent(in) :: array(:,:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
         ndarray%rank = 5
 
         if (size(array) .eq. 0) then
@@ -1564,42 +1565,42 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1))
@@ -1609,16 +1610,16 @@ module flcl_ndarray_mod
   !!! to_nd_array 6D implementations
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       function to_nd_array_l_6d(array) result(ndarray)
-        logical(c_bool), target, intent(in) :: array(:,:,:,:,:,:)
+        logical(flcl_ndarray_l_f_t), target, intent(in) :: array(:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
         ndarray%rank = 6
 
         if (size(array) .eq. 0) then
@@ -1627,50 +1628,50 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
 
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
 
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1))
@@ -1678,16 +1679,16 @@ module flcl_ndarray_mod
       end function to_nd_array_l_6d
   
       function to_nd_array_i32_6d(array) result(ndarray)
-        integer(INT32), target, intent(in) :: array(:,:,:,:,:,:)
+        integer(flcl_ndarray_i32_f_t), target, intent(in) :: array(:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
         ndarray%rank = 6
 
         if (size(array) .eq. 0) then
@@ -1696,50 +1697,50 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
 
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
 
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
 
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
 
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
 
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1))
@@ -1747,16 +1748,16 @@ module flcl_ndarray_mod
       end function to_nd_array_i32_6d
   
       function to_nd_array_i64_6d(array) result(ndarray)
-        integer(INT64), target, intent(in) :: array(:,:,:,:,:,:)
+        integer(flcl_ndarray_i64_f_t), target, intent(in) :: array(:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
         ndarray%rank = 6
 
         if (size(array) .eq. 0) then
@@ -1765,50 +1766,50 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1))
@@ -1816,16 +1817,16 @@ module flcl_ndarray_mod
       end function to_nd_array_i64_6d
   
       function to_nd_array_r32_6d(array) result(ndarray)
-        real(REAL32), target, intent(in) :: array(:,:,:,:,:,:)
+        real(flcl_ndarray_r32_f_t), target, intent(in) :: array(:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
         ndarray%rank = 6
 
         if (size(array) .eq. 0) then
@@ -1834,50 +1835,50 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1))
@@ -1885,16 +1886,16 @@ module flcl_ndarray_mod
       end function to_nd_array_r32_6d
   
       function to_nd_array_r64_6d(array) result(ndarray)
-        real(REAL64), target, intent(in) :: array(:,:,:,:,:,:)
+        real(flcl_ndarray_r64_f_t), target, intent(in) :: array(:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
         ndarray%rank = 6
 
         if (size(array) .eq. 0) then
@@ -1903,50 +1904,50 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1))
@@ -1954,16 +1955,16 @@ module flcl_ndarray_mod
       end function to_nd_array_r64_6d
   
       function to_nd_array_c32_6d(array) result(ndarray)
-        complex(c_float_complex), target, intent(in) :: array(:,:,:,:,:,:)
+        complex(flcl_ndarray_c32_f_t), target, intent(in) :: array(:,:,:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
         ndarray%rank = 6
 
         if (size(array) .eq. 0) then
@@ -1972,50 +1973,50 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1))
@@ -2023,16 +2024,16 @@ module flcl_ndarray_mod
       end function to_nd_array_c32_6d
   
       function to_nd_array_c64_6d(array) result(ndarray)
-        complex(c_double_complex), target, intent(in) :: array(:,:,:,:,:,:)
+        complex(flcl_ndarray_c64_f_t), target, intent(in) :: array(:,:,:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
         ndarray%rank = 6
 
         if (size(array) .eq. 0) then
@@ -2041,50 +2042,50 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1))
@@ -2094,17 +2095,17 @@ module flcl_ndarray_mod
   !!! to_nd_array 7D implementations
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       function to_nd_array_l_7d(array) result(ndarray)
-        logical(c_bool), target, intent(in) :: array(:,:,:,:,:,:,:)
+        logical(flcl_ndarray_l_f_t), target, intent(in) :: array(:,:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
-        ndarray%dims(7) = size(array, 7, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
+        ndarray%dims(7) = size(array, 7, flcl_ndarray_index_f_t)
         ndarray%rank = 7
 
         if (size(array) .eq. 0) then
@@ -2113,58 +2114,58 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
       
           if (size(array, 7) .ge. 2) then
             ndarray%strides(7) = &
-              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(7) = size(array, 6, c_size_t) * ndarray%strides(6)
+            ndarray%strides(7) = size(array, 6, flcl_ndarray_index_f_t) * ndarray%strides(6)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1,1))
@@ -2172,17 +2173,17 @@ module flcl_ndarray_mod
       end function to_nd_array_l_7d
   
       function to_nd_array_i32_7d(array) result(ndarray)
-        integer(INT32), target, intent(in) :: array(:,:,:,:,:,:,:)
+        integer(flcl_ndarray_i32_f_t), target, intent(in) :: array(:,:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
-        ndarray%dims(7) = size(array, 7, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
+        ndarray%dims(7) = size(array, 7, flcl_ndarray_index_f_t)
         ndarray%rank = 7
 
         if (size(array) .eq. 0) then
@@ -2191,58 +2192,58 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
       
           if (size(array, 7) .ge. 2) then
             ndarray%strides(7) = &
-              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(7) = size(array, 6, c_size_t) * ndarray%strides(6)
+            ndarray%strides(7) = size(array, 6, flcl_ndarray_index_f_t) * ndarray%strides(6)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1,1))
@@ -2250,17 +2251,17 @@ module flcl_ndarray_mod
       end function to_nd_array_i32_7d
   
       function to_nd_array_i64_7d(array) result(ndarray)
-        integer(INT64), target, intent(in) :: array(:,:,:,:,:,:,:)
+        integer(flcl_ndarray_i64_f_t), target, intent(in) :: array(:,:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
-        ndarray%dims(7) = size(array, 7, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
+        ndarray%dims(7) = size(array, 7, flcl_ndarray_index_f_t)
         ndarray%rank = 7
     
         if (size(array) .eq. 0) then
@@ -2269,58 +2270,58 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
       
           if (size(array, 7) .ge. 2) then
             ndarray%strides(7) = &
-              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(7) = size(array, 6, c_size_t) * ndarray%strides(6)
+            ndarray%strides(7) = size(array, 6, flcl_ndarray_index_f_t) * ndarray%strides(6)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1,1))
@@ -2328,17 +2329,17 @@ module flcl_ndarray_mod
       end function to_nd_array_i64_7d
   
       function to_nd_array_r32_7d(array) result(ndarray)
-        real(REAL32), target, intent(in) :: array(:,:,:,:,:,:,:)
+        real(flcl_ndarray_r32_f_t), target, intent(in) :: array(:,:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
-        ndarray%dims(7) = size(array, 7, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
+        ndarray%dims(7) = size(array, 7, flcl_ndarray_index_f_t)
         ndarray%rank = 7
 
         if (size(array) .eq. 0) then
@@ -2347,58 +2348,58 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
       
           if (size(array, 7) .ge. 2) then
             ndarray%strides(7) = &
-              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(7) = size(array, 6, c_size_t) * ndarray%strides(6)
+            ndarray%strides(7) = size(array, 6, flcl_ndarray_index_f_t) * ndarray%strides(6)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1,1))
@@ -2406,17 +2407,17 @@ module flcl_ndarray_mod
       end function to_nd_array_r32_7d
   
       function to_nd_array_r64_7d(array) result(ndarray)
-        real(REAL64), target, intent(in) :: array(:,:,:,:,:,:,:)
+        real(flcl_ndarray_r64_f_t), target, intent(in) :: array(:,:,:,:,:,:,:)
     
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
-        ndarray%dims(7) = size(array, 7, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
+        ndarray%dims(7) = size(array, 7, flcl_ndarray_index_f_t)
         ndarray%rank = 7
 
         if (size(array) .eq. 0) then
@@ -2425,58 +2426,58 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
       
           if (size(array, 7) .ge. 2) then
             ndarray%strides(7) = &
-              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(7) = size(array, 6, c_size_t) * ndarray%strides(6)
+            ndarray%strides(7) = size(array, 6, flcl_ndarray_index_f_t) * ndarray%strides(6)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1,1))
@@ -2484,17 +2485,17 @@ module flcl_ndarray_mod
       end function to_nd_array_r64_7d
   
       function to_nd_array_c32_7d(array) result(ndarray)
-        complex(c_float_complex), target, intent(in) :: array(:,:,:,:,:,:,:)
+        complex(flcl_ndarray_c32_f_t), target, intent(in) :: array(:,:,:,:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
-        ndarray%dims(7) = size(array, 7, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
+        ndarray%dims(7) = size(array, 7, flcl_ndarray_index_f_t)
         ndarray%rank = 7
 
         if (size(array) .eq. 0) then
@@ -2503,58 +2504,58 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
       
           if (size(array, 7) .ge. 2) then
             ndarray%strides(7) = &
-              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(7) = size(array, 6, c_size_t) * ndarray%strides(6)
+            ndarray%strides(7) = size(array, 6, flcl_ndarray_index_f_t) * ndarray%strides(6)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1,1))
@@ -2562,17 +2563,17 @@ module flcl_ndarray_mod
       end function to_nd_array_c32_7d
   
       function to_nd_array_c64_7d(array) result(ndarray)
-        complex(c_double_complex), target, intent(in) :: array(:,:,:,:,:,:,:)
+        complex(flcl_ndarray_c64_f_t), target, intent(in) :: array(:,:,:,:,:,:,:)
         
         type(nd_array_t) :: ndarray
     
-        ndarray%dims(1) = size(array, 1, c_size_t)
-        ndarray%dims(2) = size(array, 2, c_size_t)
-        ndarray%dims(3) = size(array, 3, c_size_t)
-        ndarray%dims(4) = size(array, 4, c_size_t)
-        ndarray%dims(5) = size(array, 5, c_size_t)
-        ndarray%dims(6) = size(array, 6, c_size_t)
-        ndarray%dims(7) = size(array, 7, c_size_t)
+        ndarray%dims(1) = size(array, 1, flcl_ndarray_index_f_t)
+        ndarray%dims(2) = size(array, 2, flcl_ndarray_index_f_t)
+        ndarray%dims(3) = size(array, 3, flcl_ndarray_index_f_t)
+        ndarray%dims(4) = size(array, 4, flcl_ndarray_index_f_t)
+        ndarray%dims(5) = size(array, 5, flcl_ndarray_index_f_t)
+        ndarray%dims(6) = size(array, 6, flcl_ndarray_index_f_t)
+        ndarray%dims(7) = size(array, 7, flcl_ndarray_index_f_t)
         ndarray%rank = 7
 
         if (size(array) .eq. 0) then
@@ -2581,58 +2582,58 @@ module flcl_ndarray_mod
         else
           if (size(array, 1) .ge. 2) then
             ndarray%strides(1) = &
-              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(2,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
             ndarray%strides(1) = 1
           end if
       
           if (size(array, 2) .ge. 2) then
             ndarray%strides(2) = &
-              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,2,1,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(2) = size(array, 1, c_size_t) * ndarray%strides(1)
+            ndarray%strides(2) = size(array, 1, flcl_ndarray_index_f_t) * ndarray%strides(1)
           end if
       
           if (size(array, 3) .ge. 2) then
             ndarray%strides(3) = &
-              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,2,1,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(3) = size(array, 2, c_size_t) * ndarray%strides(2)
+            ndarray%strides(3) = size(array, 2, flcl_ndarray_index_f_t) * ndarray%strides(2)
           end if
       
           if (size(array, 4) .ge. 2) then
             ndarray%strides(4) = &
-              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,2,1,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(4) = size(array, 3, c_size_t) * ndarray%strides(3)
+            ndarray%strides(4) = size(array, 3, flcl_ndarray_index_f_t) * ndarray%strides(3)
           end if
       
           if (size(array, 5) .ge. 2) then
             ndarray%strides(5) = &
-              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,2,1,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(5) = size(array, 4, c_size_t) * ndarray%strides(4)
+            ndarray%strides(5) = size(array, 4, flcl_ndarray_index_f_t) * ndarray%strides(4)
           end if
       
           if (size(array, 6) .ge. 2) then
             ndarray%strides(6) = &
-              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,2,1)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(6) = size(array, 5, c_size_t) * ndarray%strides(5)
+            ndarray%strides(6) = size(array, 5, flcl_ndarray_index_f_t) * ndarray%strides(5)
           end if
       
           if (size(array, 7) .ge. 2) then
             ndarray%strides(7) = &
-              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_c_size_t) - &
-              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_c_size_t)) / c_sizeof(array(1,1,1,1,1,1,1))
+              (transfer(c_loc(array(1,1,1,1,1,1,2)), 1_flcl_ndarray_index_f_t) - &
+              transfer(c_loc(array(1,1,1,1,1,1,1)), 1_flcl_ndarray_index_f_t)) / c_sizeof(array(1,1,1,1,1,1,1))
           else
-            ndarray%strides(7) = size(array, 6, c_size_t) * ndarray%strides(6)
+            ndarray%strides(7) = size(array, 6, flcl_ndarray_index_f_t) * ndarray%strides(6)
           end if
 
           ndarray%data = c_loc(array(1,1,1,1,1,1,1))

--- a/src/flcl-types-cxx.hpp
+++ b/src/flcl-types-cxx.hpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for
+// Los Alamos National Laboratory (LANL), which is operated by Triad National
+// Security, LLC for the U.S. Department of Energy/National Nuclear Security
+// Administration. All rights in the program are reserved by Triad National
+// Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others acting on
+// its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+// material to reproduce, prepare derivative works, distribute copies to the
+// public, perform publicly and display publicly, and to permit others to do so.
+//
+// This program is open source under the BSD-3 License.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright
+//   notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//   notice, this list of conditions and the following disclaimer in the
+//   documentation and/or other materials provided with the distribution.
+// 3. Neither the name of the copyright holder nor the
+//   names of its contributors may be used to endorse or promote products
+//   derived from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+// DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef FLCL_TYPES_CXX_HPP
+#define FLCL_TYPES_CXX_HPP
+
+#include <complex>
+
+  namespace flcl {
+
+    // FLCL primary scalar types
+    // - modify at this level to change ndarray, view, and dualview simultaneously
+    // - ensure compatibility with F side
+    typedef bool                    flcl_l_c_t;
+
+    typedef int32_t                 flcl_i32_c_t;
+    typedef int64_t                 flcl_i64_c_t;
+
+    typedef float                   flcl_r32_c_t;
+    typedef double                  flcl_r64_c_t;
+
+    typedef std::complex<float>     flcl_c32_c_t;
+    typedef std::complex<double>    flcl_c64_c_t;
+
+    typedef size_t                  flcl_index_c_t;
+
+// FLCL ndarray scalar types
+// - modify at this level to change ndarray only
+// - ensure compatibility with F side at this level
+    typedef flcl_l_c_t              flcl_ndarray_l_c_t;
+    typedef flcl_i32_c_t            flcl_ndarray_i32_c_t;
+    typedef flcl_i64_c_t            flcl_ndarray_i64_c_t;
+    typedef flcl_r32_c_t            flcl_ndarray_r32_c_t;
+    typedef flcl_r64_c_t            flcl_ndarray_r64_c_t;
+    typedef flcl_c32_c_t            flcl_ndarray_c32_c_t;
+    typedef flcl_c64_c_t            flcl_ndarray_c64_c_t;
+    typedef flcl_index_c_t          flcl_ndarray_index_c_t;
+
+// FLCL view scalar types
+// - modify at this level to change view only
+// - ensure compatibility with F side at this level
+    typedef flcl_l_c_t              flcl_view_l_c_t;
+    typedef flcl_i32_c_t            flcl_view_i32_c_t;
+    typedef flcl_i64_c_t            flcl_view_i64_c_t;
+    typedef flcl_r32_c_t            flcl_view_r32_c_t;
+    typedef flcl_r64_c_t            flcl_view_r64_c_t;
+    typedef flcl_c32_c_t            flcl_view_c32_c_t;
+    typedef flcl_c64_c_t            flcl_view_c64_c_t;
+    typedef flcl_index_c_t          flcl_view_index_c_t;
+
+// FLCL dualview scalar types
+// - modify at this level to change dualview only
+// - ensure compatibility with F side at this level
+    typedef flcl_l_c_t              flcl_dualview_l_c_t;
+    typedef flcl_i32_c_t            flcl_dualview_i32_c_t;
+    typedef flcl_i64_c_t            flcl_dualview_i64_c_t;
+    typedef flcl_r32_c_t            flcl_dualview_r32_c_t;
+    typedef flcl_r64_c_t            flcl_dualview_r64_c_t;
+    typedef flcl_c32_c_t            flcl_dualview_c32_c_t;
+    typedef flcl_c64_c_t            flcl_dualview_c64_c_t;
+    typedef flcl_index_c_t          flcl_dualview_index_c_t;
+
+  } // namespace flcl
+  
+#endif // FLCL_TYPES_CXX_HPP

--- a/src/flcl-types-cxx.hpp
+++ b/src/flcl-types-cxx.hpp
@@ -61,38 +61,38 @@
 // FLCL ndarray scalar types
 // - modify at this level to change ndarray only
 // - ensure compatibility with F side at this level
-    typedef flcl_l_c_t              flcl_ndarray_l_c_t;
-    typedef flcl_i32_c_t            flcl_ndarray_i32_c_t;
-    typedef flcl_i64_c_t            flcl_ndarray_i64_c_t;
-    typedef flcl_r32_c_t            flcl_ndarray_r32_c_t;
-    typedef flcl_r64_c_t            flcl_ndarray_r64_c_t;
-    typedef flcl_c32_c_t            flcl_ndarray_c32_c_t;
-    typedef flcl_c64_c_t            flcl_ndarray_c64_c_t;
-    typedef flcl_index_c_t          flcl_ndarray_index_c_t;
+    using flcl_ndarray_l_c_t = flcl_l_c_t;
+    using flcl_ndarray_i32_c_t = flcl_i32_c_t;
+    using flcl_ndarray_i64_c_t = flcl_i64_c_t;
+    using flcl_ndarray_r32_c_t = flcl_r32_c_t;
+    using flcl_ndarray_r64_c_t = flcl_r64_c_t;
+    using flcl_ndarray_c32_c_t = flcl_c32_c_t;
+    using flcl_ndarray_c64_c_t = flcl_c64_c_t;
+    using flcl_ndarray_index_c_t = flcl_index_c_t;
 
 // FLCL view scalar types
 // - modify at this level to change view only
 // - ensure compatibility with F side at this level
-    typedef flcl_l_c_t              flcl_view_l_c_t;
-    typedef flcl_i32_c_t            flcl_view_i32_c_t;
-    typedef flcl_i64_c_t            flcl_view_i64_c_t;
-    typedef flcl_r32_c_t            flcl_view_r32_c_t;
-    typedef flcl_r64_c_t            flcl_view_r64_c_t;
-    typedef flcl_c32_c_t            flcl_view_c32_c_t;
-    typedef flcl_c64_c_t            flcl_view_c64_c_t;
-    typedef flcl_index_c_t          flcl_view_index_c_t;
+    using flcl_view_l_c_t = flcl_l_c_t;
+    using flcl_view_i32_c_t = flcl_i32_c_t;
+    using flcl_view_i64_c_t = flcl_i64_c_t;
+    using flcl_view_r32_c_t = flcl_r32_c_t;
+    using flcl_view_r64_c_t = flcl_r64_c_t;
+    using flcl_view_c32_c_t = flcl_c32_c_t;
+    using flcl_view_c64_c_t = flcl_c64_c_t;
+    using flcl_view_index_c_t = flcl_index_c_t;
 
 // FLCL dualview scalar types
 // - modify at this level to change dualview only
 // - ensure compatibility with F side at this level
-    typedef flcl_l_c_t              flcl_dualview_l_c_t;
-    typedef flcl_i32_c_t            flcl_dualview_i32_c_t;
-    typedef flcl_i64_c_t            flcl_dualview_i64_c_t;
-    typedef flcl_r32_c_t            flcl_dualview_r32_c_t;
-    typedef flcl_r64_c_t            flcl_dualview_r64_c_t;
-    typedef flcl_c32_c_t            flcl_dualview_c32_c_t;
-    typedef flcl_c64_c_t            flcl_dualview_c64_c_t;
-    typedef flcl_index_c_t          flcl_dualview_index_c_t;
+    using flcl_dualview_l_c_t = flcl_l_c_t;
+    using flcl_dualview_i32_c_t = flcl_i32_c_t;
+    using flcl_dualview_i64_c_t = flcl_i64_c_t;
+    using flcl_dualview_r32_c_t = flcl_r32_c_t;
+    using flcl_dualview_r64_c_t = flcl_r64_c_t;
+    using flcl_dualview_c32_c_t = flcl_c32_c_t;
+    using flcl_dualview_c64_c_t = flcl_c64_c_t;
+    using flcl_dualview_index_c_t = flcl_index_c_t;
 
   } // namespace flcl
   

--- a/src/flcl-types-cxx.hpp
+++ b/src/flcl-types-cxx.hpp
@@ -45,18 +45,20 @@
     // FLCL primary scalar types
     // - modify at this level to change ndarray, view, and dualview simultaneously
     // - ensure compatibility with F side
-    typedef bool                    flcl_l_c_t;
+    typedef bool                                flcl_l_c_t;
 
-    typedef int32_t                 flcl_i32_c_t;
-    typedef int64_t                 flcl_i64_c_t;
+    typedef int32_t                             flcl_i32_c_t;
+    typedef int64_t                             flcl_i64_c_t;
 
-    typedef float                   flcl_r32_c_t;
-    typedef double                  flcl_r64_c_t;
+    typedef float                               flcl_r32_c_t;
+    typedef double                              flcl_r64_c_t;
 
-    typedef std::complex<float>     flcl_c32_c_t;
-    typedef std::complex<double>    flcl_c64_c_t;
+    typedef float                               flcl_c32_scalar_c_t;
+    typedef double                              flcl_c64_scalar_c_t;
+    typedef std::complex<flcl_c32_scalar_c_t>   flcl_c32_c_t;
+    typedef std::complex<flcl_c64_scalar_c_t>   flcl_c64_c_t;
 
-    typedef size_t                  flcl_index_c_t;
+    typedef size_t                              flcl_index_c_t;
 
 // FLCL ndarray scalar types
 // - modify at this level to change ndarray only
@@ -66,6 +68,8 @@
     using flcl_ndarray_i64_c_t = flcl_i64_c_t;
     using flcl_ndarray_r32_c_t = flcl_r32_c_t;
     using flcl_ndarray_r64_c_t = flcl_r64_c_t;
+    using flcl_ndarray_c32_scalar_c_t = flcl_c32_scalar_c_t;
+    using flcl_ndarray_c64_scalar_c_t = flcl_c64_scalar_c_t;
     using flcl_ndarray_c32_c_t = flcl_c32_c_t;
     using flcl_ndarray_c64_c_t = flcl_c64_c_t;
     using flcl_ndarray_index_c_t = flcl_index_c_t;

--- a/src/flcl-types-f.f90
+++ b/src/flcl-types-f.f90
@@ -1,0 +1,104 @@
+! Copyright (c) 2019. Triad National Security, LLC. All rights reserved.
+!
+! This program was produced under U.S. Government contract 89233218CNA000001 for
+! Los Alamos National Laboratory (LANL), which is operated by Triad National
+! Security, LLC for the U.S. Department of Energy/National Nuclear Security
+! Administration. All rights in the program are reserved by Triad National
+! Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+! Administration. The Government is granted for itself and others acting on
+! its behalf a nonexclusive, paid-up, irrevocable worldwide license in this
+! material to reproduce, prepare derivative works, distribute copies to the
+! public, perform publicly and display publicly, and to permit others to do so.
+!
+! This program is open source under the BSD-3 License.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification,
+! are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+!   notice, this list of conditions and the following disclaimer.
+! 2. Redistributions in binary form must reproduce the above copyright
+!   notice, this list of conditions and the following disclaimer in the
+!   documentation and/or other materials provided with the distribution.
+! 3. Neither the name of the copyright holder nor the
+!   names of its contributors may be used to endorse or promote products
+!   derived from this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+! AND
+! ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+! WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+! FOR ANY
+! DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+! (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+! ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+module flcl_types_f_mod
+  
+  use iso_c_binding
+
+  implicit none
+
+  public
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! FLCL primary scalar types
+!!! - modify at this level to change ndarray, view, and dualview simultaneously
+!!! - ensure compatibility with C side
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    integer, parameter :: flcl_l_f_t   = c_bool
+
+    integer, parameter :: flcl_i32_f_t = c_int32_t
+    integer, parameter :: flcl_i64_f_t = c_int64_t
+
+    integer, parameter :: flcl_r32_f_t = c_float 
+    integer, parameter :: flcl_r64_f_t = c_double
+
+    integer, parameter :: flcl_c32_f_t = c_float_complex
+    integer, parameter :: flcl_c64_f_t = c_double_complex
+
+    integer, parameter :: flcl_index_f_t = c_size_t
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! FLCL ndarray scalar types
+!!! - modify at this level to change ndarray only
+!!! - ensure compatibility with C side at this level
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    integer, parameter :: flcl_ndarray_l_f_t     = flcl_l_f_t
+    integer, parameter :: flcl_ndarray_i32_f_t   = flcl_i32_f_t
+    integer, parameter :: flcl_ndarray_i64_f_t   = flcl_i64_f_t
+    integer, parameter :: flcl_ndarray_r32_f_t   = flcl_r32_f_t
+    integer, parameter :: flcl_ndarray_r64_f_t   = flcl_r64_f_t
+    integer, parameter :: flcl_ndarray_c32_f_t   = flcl_c32_f_t
+    integer, parameter :: flcl_ndarray_c64_f_t   = flcl_c64_f_t
+    integer, parameter :: flcl_ndarray_index_f_t = flcl_index_f_t
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! FLCL view scalar types
+!!! - modify at this level to change view only
+!!! - ensure compatibility with C side at this level
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    integer, parameter :: flcl_view_l_f_t     = flcl_l_f_t
+    integer, parameter :: flcl_view_i32_f_t   = flcl_i32_f_t
+    integer, parameter :: flcl_view_i64_f_t   = flcl_i64_f_t
+    integer, parameter :: flcl_view_r32_f_t   = flcl_r32_f_t
+    integer, parameter :: flcl_view_r64_f_t   = flcl_r64_f_t
+    integer, parameter :: flcl_view_c32_f_t   = flcl_c32_f_t
+    integer, parameter :: flcl_view_c64_f_t   = flcl_c64_f_t
+    integer, parameter :: flcl_view_index_f_t = flcl_index_f_t
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! FLCL dualview scalar types
+!!! - modify at this level to change dualview only
+!!! - ensure compatibility with C side at this level
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    integer, parameter :: flcl_dualview_l_f_t     = flcl_l_f_t
+    integer, parameter :: flcl_dualview_i32_f_t   = flcl_i32_f_t
+    integer, parameter :: flcl_dualview_i64_f_t   = flcl_i64_f_t
+    integer, parameter :: flcl_dualview_r32_f_t   = flcl_r32_f_t
+    integer, parameter :: flcl_dualview_r64_f_t   = flcl_r64_f_t
+    integer, parameter :: flcl_dualview_c32_f_t   = flcl_c32_f_t
+    integer, parameter :: flcl_dualview_c64_f_t   = flcl_c64_f_t
+    integer, parameter :: flcl_dualview_index_f_t = flcl_index_f_t
+
+end module flcl_types_f_mod

--- a/src/flcl-view-f.f90
+++ b/src/flcl-view-f.f90
@@ -39,7 +39,7 @@ module flcl_view_mod
   use, intrinsic :: iso_c_binding
   use, intrinsic :: iso_fortran_env
   use flcl_util_strings_mod, only: char_add_null
-  
+  use flcl_types_f_mod 
   implicit none
   private
   
@@ -453,11 +453,12 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_l_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_v_l_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0      
+      integer(flcl_view_index_f_t), intent(in) :: e0      
     end subroutine f_kokkos_allocate_v_l_1d
   end interface
 
@@ -465,11 +466,12 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i32_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_v_i32_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_v_i32_1d
   end interface
   
@@ -477,11 +479,12 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i64_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_v_i64_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_v_i64_1d
   end interface
 
@@ -489,11 +492,12 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r32_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_v_r32_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_v_r32_1d
   end interface
   
@@ -501,11 +505,12 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r64_1d(c_A, v_A, n_A, e0) &
       & bind (c, name='c_kokkos_allocate_v_r64_1d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
     end subroutine f_kokkos_allocate_v_r64_1d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -515,12 +520,13 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_l_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_v_l_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod      
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_v_l_2d
   end interface
   
@@ -528,12 +534,13 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i32_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_v_i32_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_v_i32_2d
   end interface
 
@@ -541,12 +548,13 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i64_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_v_i64_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_v_i64_2d
   end interface
   
@@ -554,12 +562,13 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r32_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_v_r32_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_v_r32_2d
   end interface
 
@@ -567,12 +576,13 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r64_2d(c_A, v_A, n_A, e0, e1) &
       & bind (c, name='c_kokkos_allocate_v_r64_2d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
     end subroutine f_kokkos_allocate_v_r64_2d
   end interface  
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -582,13 +592,14 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_l_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_v_l_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_v_l_3d
   end interface
 
@@ -596,13 +607,14 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i32_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_v_i32_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_v_i32_3d
   end interface
   
@@ -610,13 +622,14 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i64_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_v_i64_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_v_i64_3d
   end interface
 
@@ -624,13 +637,14 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r32_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_v_r32_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_v_r32_3d
   end interface
   
@@ -638,13 +652,14 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r64_3d(c_A, v_A, n_A, e0, e1, e2) &
       & bind (c, name='c_kokkos_allocate_v_r64_3d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
     end subroutine f_kokkos_allocate_v_r64_3d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -654,14 +669,15 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_l_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_v_l_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_v_l_4d
   end interface
 
@@ -669,14 +685,15 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i32_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_v_i32_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_v_i32_4d
   end interface
   
@@ -684,14 +701,15 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i64_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_v_i64_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_v_i64_4d
   end interface
 
@@ -699,14 +717,15 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r32_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_v_r32_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_v_r32_4d
   end interface
   
@@ -714,14 +733,15 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r64_4d(c_A, v_A, n_A, e0, e1, e2, e3) &
       & bind (c, name='c_kokkos_allocate_v_r64_4d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
     end subroutine f_kokkos_allocate_v_r64_4d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -731,15 +751,16 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_l_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_v_l_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_v_l_5d
   end interface
 
@@ -747,15 +768,16 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i32_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_v_i32_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_v_i32_5d
   end interface
   
@@ -763,15 +785,16 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i64_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_v_i64_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_v_i64_5d
   end interface
 
@@ -779,15 +802,16 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r32_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_v_r32_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_v_r32_5d
   end interface
   
@@ -795,15 +819,16 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r64_5d(c_A, v_A, n_A, e0, e1, e2, e3, e4) &
       & bind (c, name='c_kokkos_allocate_v_r64_5d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
     end subroutine f_kokkos_allocate_v_r64_5d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -813,16 +838,17 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_l_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_v_l_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_v_l_6d
   end interface
 
@@ -830,16 +856,17 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i32_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_v_i32_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_v_i32_6d
   end interface
   
@@ -847,16 +874,17 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i64_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_v_i64_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_v_i64_6d
   end interface
 
@@ -864,16 +892,17 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r32_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_v_r32_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_v_r32_6d
   end interface
   
@@ -881,16 +910,17 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r64_6d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5) &
       & bind (c, name='c_kokkos_allocate_v_r64_6d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
     end subroutine f_kokkos_allocate_v_r64_6d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -900,17 +930,18 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_l_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_v_l_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_v_l_7d
   end interface
 
@@ -918,17 +949,18 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i32_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_v_i32_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_v_i32_7d
   end interface
   
@@ -936,17 +968,18 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_i64_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_v_i64_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_v_i64_7d
   end interface
 
@@ -954,17 +987,18 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r32_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_v_r32_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_v_r32_7d
   end interface
   
@@ -972,17 +1006,18 @@ module flcl_view_mod
     subroutine f_kokkos_allocate_v_r64_7d(c_A, v_A, n_A, e0, e1, e2, e3, e4, e5, e6) &
       & bind (c, name='c_kokkos_allocate_v_r64_7d')
       use, intrinsic :: iso_c_binding
+      use flcl_types_f_mod
       implicit none
       type(c_ptr), intent(out) :: c_A
       type(c_ptr), intent(out) :: v_A
       character(kind=c_char), intent(in) :: n_A(*)
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
     end subroutine f_kokkos_allocate_v_r64_7d
   end interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1325,10 +1360,10 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_l_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
       
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1342,10 +1377,10 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer (INT32), pointer, dimension(:), intent(inout) :: A
+      integer (flcl_view_i32_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_i32_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
       
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1359,10 +1394,10 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_i64_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
       
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1376,10 +1411,10 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_r32_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1393,10 +1428,10 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_r64_1d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e0
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1412,11 +1447,11 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_l_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1430,11 +1465,11 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_i32_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1448,11 +1483,11 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer (INT64), pointer, dimension(:,:), intent(inout) :: A
+      integer (flcl_view_i64_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_i64_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1466,11 +1501,11 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_r32_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1484,11 +1519,11 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_r64_2d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1504,12 +1539,12 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_l_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1523,12 +1558,12 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_i32_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1542,12 +1577,12 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_i64_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1561,12 +1596,12 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_r32_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1580,12 +1615,12 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_r64_3d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1601,13 +1636,13 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_l_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1621,13 +1656,13 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_i32_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1641,13 +1676,13 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_i64_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1661,13 +1696,13 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_r32_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1681,13 +1716,13 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_r64_4d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1703,14 +1738,14 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_l_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1724,14 +1759,14 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_i32_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1745,14 +1780,14 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_i64_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1766,14 +1801,14 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_r32_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1787,14 +1822,14 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_r64_5d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1810,15 +1845,15 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_l_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1832,15 +1867,15 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_i32_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1854,15 +1889,15 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_i64_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1876,15 +1911,15 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_r32_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1898,15 +1933,15 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_r64_6d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1922,16 +1957,16 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_l_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1945,16 +1980,16 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_i32_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1968,16 +2003,16 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_i64_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -1991,16 +2026,16 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_r32_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
   
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -2014,16 +2049,16 @@ module flcl_view_mod
       use, intrinsic :: iso_c_binding
       use flcl_util_strings_mod, only: char_add_null
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_r64_7d_t), intent(out) :: v_A
       character(len=*), intent(in) :: n_A
-      integer(c_size_t), intent(in) :: e0
-      integer(c_size_t), intent(in) :: e1
-      integer(c_size_t), intent(in) :: e2
-      integer(c_size_t), intent(in) :: e3
-      integer(c_size_t), intent(in) :: e4
-      integer(c_size_t), intent(in) :: e5
-      integer(c_size_t), intent(in) :: e6
+      integer(flcl_view_index_f_t), intent(in) :: e0
+      integer(flcl_view_index_f_t), intent(in) :: e1
+      integer(flcl_view_index_f_t), intent(in) :: e2
+      integer(flcl_view_index_f_t), intent(in) :: e3
+      integer(flcl_view_index_f_t), intent(in) :: e4
+      integer(flcl_view_index_f_t), intent(in) :: e5
+      integer(flcl_view_index_f_t), intent(in) :: e6
       type(c_ptr) :: c_A
 
       character(len=:, kind=c_char), allocatable, target :: f_label
@@ -2038,7 +2073,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_l_1d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      logical(c_bool), pointer, dimension(:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_l_1d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2050,7 +2085,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i32_1d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT32), pointer, dimension(:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_i32_1d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2062,7 +2097,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i64_1d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT64), pointer, dimension(:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_i64_1d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2074,7 +2109,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r32_1d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL32), pointer, dimension(:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_r32_1d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2086,7 +2121,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r64_1d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL64), pointer, dimension(:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:), intent(inout) :: A
       type(view_r64_1d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2100,7 +2135,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_l_2d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      logical(c_bool), pointer, dimension(:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_l_2d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2112,7 +2147,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i32_2d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT32), pointer, dimension(:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_i32_2d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2124,7 +2159,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i64_2d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT64), pointer, dimension(:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_i64_2d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2136,7 +2171,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r32_2d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL32), pointer, dimension(:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_r32_2d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2148,7 +2183,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r64_2d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL64), pointer, dimension(:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:), intent(inout) :: A
       type(view_r64_2d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2162,7 +2197,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_l_3d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_l_3d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2174,7 +2209,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i32_3d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT32), pointer, dimension(:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_i32_3d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2186,7 +2221,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i64_3d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT64), pointer, dimension(:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_i64_3d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2198,7 +2233,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r32_3d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL32), pointer, dimension(:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_r32_3d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2210,7 +2245,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r64_3d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL64), pointer, dimension(:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:), intent(inout) :: A
       type(view_r64_3d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2224,7 +2259,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_l_4d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_l_4d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2236,7 +2271,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i32_4d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_i32_4d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2248,7 +2283,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i64_4d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_i64_4d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2260,7 +2295,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r32_4d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_r32_4d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2272,7 +2307,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r64_4d(A, v_A )
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:), intent(inout) :: A
       type(view_r64_4d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2286,7 +2321,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_l_5d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_l_5d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2298,7 +2333,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i32_5d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_i32_5d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2310,7 +2345,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i64_5d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_i64_5d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2322,7 +2357,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r32_5d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_r32_5d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2334,7 +2369,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r64_5d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:), intent(inout) :: A
       type(view_r64_5d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2348,7 +2383,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_l_6d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_l_6d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2360,7 +2395,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i32_6d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_i32_6d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2372,7 +2407,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i64_6d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_i64_6d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2384,7 +2419,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r32_6d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_r32_6d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2396,7 +2431,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r64_6d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:,:), intent(inout) :: A
       type(view_r64_6d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2410,7 +2445,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_l_7d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      logical(c_bool), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_l_7d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2422,7 +2457,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i32_7d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_i32_7d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2434,7 +2469,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_i64_7d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      integer(INT64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_i64_7d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2446,7 +2481,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r32_7d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL32), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_r32_7d_t), intent(inout) :: v_A
   
       A => NULL()
@@ -2458,7 +2493,7 @@ module flcl_view_mod
     subroutine kokkos_deallocate_v_r64_7d(A, v_A)
       use, intrinsic :: iso_c_binding
       implicit none
-      real(REAL64), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
+      real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:,:,:), intent(inout) :: A
       type(view_r64_7d_t), intent(inout) :: v_A
   
       A => NULL()

--- a/test/flcl-test-cxx.cpp
+++ b/test/flcl-test-cxx.cpp
@@ -45,11 +45,11 @@
 
 extern "C" {
 
-  size_t c_test_ndarray_l_1d( flcl_ndarray_t *nd_array_l_1d, size_t *f_sum ) {
+  flcl::flcl_ndarray_index_c_t c_test_ndarray_l_1d( flcl_ndarray_t *nd_array_l_1d, flcl::flcl_ndarray_index_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_l_1d = view_from_ndarray<bool*>(*nd_array_l_1d);
+    flcl::flcl_ndarray_index_c_t c_sum = 0;
+    auto array_l_1d = view_from_ndarray<flcl::flcl_ndarray_l_c_t*>(*nd_array_l_1d);
 
     for (size_t ii = 0; ii < array_l_1d.extent(0); ii++) {
       if ( array_l_1d(ii) ) c_sum++;
@@ -69,11 +69,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i32_1d( flcl_ndarray_t *nd_array_i32_1d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i32_c_t c_test_ndarray_i32_1d( flcl_ndarray_t *nd_array_i32_1d, flcl::flcl_ndarray_i32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i32_1d = view_from_ndarray<int32_t*>(*nd_array_i32_1d);
+    flcl::flcl_ndarray_i32_c_t c_sum = 0;
+    auto array_i32_1d = view_from_ndarray<flcl::flcl_ndarray_i32_c_t*>(*nd_array_i32_1d);
     
     for (size_t ii = 0; ii < array_i32_1d.extent(0); ii++) {
       c_sum = c_sum + array_i32_1d(ii);
@@ -95,11 +95,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i64_1d( flcl_ndarray_t *nd_array_i64_1d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i64_c_t c_test_ndarray_i64_1d( flcl_ndarray_t *nd_array_i64_1d, flcl::flcl_ndarray_i64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i64_1d = view_from_ndarray<int64_t*>(*nd_array_i64_1d);
+    flcl::flcl_ndarray_i64_c_t c_sum = 0;
+    auto array_i64_1d = view_from_ndarray<flcl::flcl_ndarray_i64_c_t*>(*nd_array_i64_1d);
 
     for (size_t ii = 0; ii < array_i64_1d.extent(0); ii++) {
       c_sum = c_sum + array_i64_1d(ii);
@@ -121,11 +121,11 @@ extern "C" {
     return c_sum;
   }
 
-  float c_test_ndarray_r32_1d( flcl_ndarray_t *nd_array_r32_1d, float *f_sum ) {
+  flcl::flcl_ndarray_r32_c_t c_test_ndarray_r32_1d( flcl_ndarray_t *nd_array_r32_1d, flcl::flcl_ndarray_r32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    float c_sum = 0;
-    auto array_r32_1d = view_from_ndarray<float*>(*nd_array_r32_1d);
+    flcl::flcl_ndarray_r32_c_t c_sum = 0;
+    auto array_r32_1d = view_from_ndarray<flcl::flcl_ndarray_r32_c_t*>(*nd_array_r32_1d);
 
     for (size_t ii = 0; ii < array_r32_1d.extent(0); ii++) {
       c_sum = c_sum + array_r32_1d(ii);
@@ -149,11 +149,11 @@ extern "C" {
     return c_sum;
   }
 
-  double c_test_ndarray_r64_1d( flcl_ndarray_t *nd_array_r64_1d, double *f_sum ) {
+  flcl::flcl_ndarray_r64_c_t c_test_ndarray_r64_1d( flcl_ndarray_t *nd_array_r64_1d, flcl::flcl_ndarray_r64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    double c_sum = 0;
-    auto array_r64_1d = view_from_ndarray<double*>(*nd_array_r64_1d);
+    flcl::flcl_ndarray_r64_c_t c_sum = 0;
+    auto array_r64_1d = view_from_ndarray<flcl::flcl_ndarray_r64_c_t*>(*nd_array_r64_1d);
 
     for (size_t ii = 0; ii < array_r64_1d.extent(0); ii++) {
       c_sum = c_sum + array_r64_1d(ii);
@@ -177,12 +177,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<float> c_test_ndarray_c32_1d( flcl_ndarray_t *nd_array_c32_1d, std::complex<float> *f_sum ) {
+  flcl::flcl_ndarray_c32_c_t c_test_ndarray_c32_1d( flcl_ndarray_t *nd_array_c32_1d, flcl::flcl_ndarray_c32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
     
-    Kokkos::complex<float> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c32_1d = view_from_ndarray<Kokkos::complex<float>*>(*nd_array_c32_1d);
+    auto array_c32_1d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>*>(*nd_array_c32_1d);
     for (size_t ii = 0; ii < array_c32_1d.extent(0); ii++) {
       c_sum = c_sum + array_c32_1d(ii);
     }
@@ -201,21 +201,21 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
 
-    c_sum = Kokkos::complex<float>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c32_1d.extent(0); ii++) {
-      array_c32_1d(ii) = Kokkos::complex<float>(1.0*(ii),-1.0*(ii));
+      array_c32_1d(ii) = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(1.0*(ii),-1.0*(ii));
       c_sum = c_sum + array_c32_1d(ii);
     }
 
     return c_sum;
   }
 
-  std::complex<double> c_test_ndarray_c64_1d( flcl_ndarray_t *nd_array_c64_1d, std::complex<double> *f_sum ) {
+  flcl::flcl_ndarray_c64_c_t c_test_ndarray_c64_1d( flcl_ndarray_t *nd_array_c64_1d, flcl::flcl_ndarray_c64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    Kokkos::complex<double> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c64_1d = view_from_ndarray<Kokkos::complex<double>*>(*nd_array_c64_1d);
+    auto array_c64_1d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>*>(*nd_array_c64_1d);
     for (size_t ii = 0; ii < array_c64_1d.extent(0); ii++) {
       c_sum = c_sum + array_c64_1d(ii);
     }
@@ -234,9 +234,9 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
     
-    c_sum = Kokkos::complex<double>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c64_1d.extent(0); ii++) {
-      array_c64_1d(ii) = Kokkos::complex<double>(1.0*(ii),-1.0*(ii));
+      array_c64_1d(ii) = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(1.0*(ii),-1.0*(ii));
       c_sum = c_sum + array_c64_1d(ii);
     }
 
@@ -244,11 +244,11 @@ extern "C" {
 
   }
 
-  size_t c_test_ndarray_l_2d( flcl_ndarray_t *nd_array_l_2d, size_t *f_sum ) {
+  flcl::flcl_ndarray_index_c_t c_test_ndarray_l_2d( flcl_ndarray_t *nd_array_l_2d, flcl::flcl_ndarray_index_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_l_2d = view_from_ndarray<bool**>(*nd_array_l_2d);
+    flcl::flcl_ndarray_index_c_t c_sum = 0;
+    auto array_l_2d = view_from_ndarray<flcl::flcl_ndarray_l_c_t**>(*nd_array_l_2d);
 
     for (size_t ii = 0; ii < array_l_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_l_2d.extent(1); jj++) { 
@@ -272,11 +272,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i32_2d( flcl_ndarray_t *nd_array_i32_2d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i32_c_t c_test_ndarray_i32_2d( flcl_ndarray_t *nd_array_i32_2d, flcl::flcl_ndarray_i32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i32_2d = view_from_ndarray<int32_t**>(*nd_array_i32_2d);
+    flcl::flcl_ndarray_i32_c_t c_sum = 0;
+    auto array_i32_2d = view_from_ndarray<flcl::flcl_ndarray_i32_c_t**>(*nd_array_i32_2d);
 
     for (size_t ii = 0; ii < array_i32_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i32_2d.extent(1); jj++) {
@@ -302,11 +302,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i64_2d( flcl_ndarray_t *nd_array_i64_2d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i64_c_t c_test_ndarray_i64_2d( flcl_ndarray_t *nd_array_i64_2d, flcl::flcl_ndarray_i64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i64_2d = view_from_ndarray<int64_t**>(*nd_array_i64_2d);
+    flcl::flcl_ndarray_i64_c_t c_sum = 0;
+    auto array_i64_2d = view_from_ndarray<flcl::flcl_ndarray_i64_c_t**>(*nd_array_i64_2d);
 
     for (size_t ii = 0; ii < array_i64_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i64_2d.extent(1); jj++) {
@@ -332,11 +332,11 @@ extern "C" {
     return c_sum;
   }
 
-  float c_test_ndarray_r32_2d( flcl_ndarray_t *nd_array_r32_2d, float *f_sum ) {
+  flcl::flcl_ndarray_r32_c_t c_test_ndarray_r32_2d( flcl_ndarray_t *nd_array_r32_2d, flcl::flcl_ndarray_r32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    float c_sum = 0;
-    auto array_r32_2d = view_from_ndarray<float**>(*nd_array_r32_2d);
+    flcl::flcl_ndarray_r32_c_t c_sum = 0;
+    auto array_r32_2d = view_from_ndarray<flcl::flcl_ndarray_r32_c_t**>(*nd_array_r32_2d);
 
     for (size_t ii = 0; ii < array_r32_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r32_2d.extent(1); jj++) {
@@ -364,11 +364,11 @@ extern "C" {
     return c_sum;
   }
 
-  double c_test_ndarray_r64_2d( flcl_ndarray_t *nd_array_r64_2d, double *f_sum ) {
+  flcl::flcl_ndarray_r64_c_t c_test_ndarray_r64_2d( flcl_ndarray_t *nd_array_r64_2d, flcl::flcl_ndarray_r64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    double c_sum = 0;
-    auto array_r64_2d = view_from_ndarray<double**>(*nd_array_r64_2d);
+    flcl::flcl_ndarray_r64_c_t c_sum = 0;
+    auto array_r64_2d = view_from_ndarray<flcl::flcl_ndarray_r64_c_t**>(*nd_array_r64_2d);
 
     for (size_t ii = 0; ii < array_r64_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r64_2d.extent(1); jj++) {
@@ -396,12 +396,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<float> c_test_ndarray_c32_2d( flcl_ndarray_t *nd_array_c32_2d, std::complex<float> *f_sum ) {
+  flcl::flcl_ndarray_c32_c_t c_test_ndarray_c32_2d( flcl_ndarray_t *nd_array_c32_2d, flcl::flcl_ndarray_c32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
     
-    Kokkos::complex<float> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c32_2d = view_from_ndarray<Kokkos::complex<float>**>(*nd_array_c32_2d);
+    auto array_c32_2d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>**>(*nd_array_c32_2d);
     for (size_t ii = 0; ii < array_c32_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_2d.extent(1); jj++) {
         c_sum = c_sum + array_c32_2d(ii,jj);
@@ -422,10 +422,10 @@ extern "C" {
       exit(EXIT_FAILURE);
     }
 
-    c_sum = Kokkos::complex<float>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c32_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_2d.extent(1); jj++) {
-        array_c32_2d(ii,jj) = Kokkos::complex<float>(1.0*(ii+jj),-1.0*(ii+jj));
+        array_c32_2d(ii,jj) = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(1.0*(ii+jj),-1.0*(ii+jj));
         c_sum = c_sum + array_c32_2d(ii,jj);
       }
     }
@@ -433,12 +433,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<double> c_test_ndarray_c64_2d( flcl_ndarray_t *nd_array_c64_2d, std::complex<double> *f_sum ) {
+  flcl::flcl_ndarray_c64_c_t c_test_ndarray_c64_2d( flcl_ndarray_t *nd_array_c64_2d, flcl::flcl_ndarray_c64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    Kokkos::complex<double> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c64_2d = view_from_ndarray<Kokkos::complex<double>**>(*nd_array_c64_2d);
+    auto array_c64_2d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>**>(*nd_array_c64_2d);
     for (size_t ii = 0; ii < array_c64_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_2d.extent(1); jj++) {
         c_sum = c_sum + array_c64_2d(ii,jj);
@@ -459,10 +459,10 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
     
-    c_sum = Kokkos::complex<double>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c64_2d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_2d.extent(1); jj++) {
-        array_c64_2d(ii,jj) = Kokkos::complex<double>(1.0*(ii+jj),-1.0*(ii+jj));
+        array_c64_2d(ii,jj) = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(1.0*(ii+jj),-1.0*(ii+jj));
         c_sum = c_sum + array_c64_2d(ii,jj);
       }
     }
@@ -470,11 +470,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_l_3d( flcl_ndarray_t *nd_array_l_3d, size_t *f_sum ) {
+  flcl::flcl_ndarray_index_c_t c_test_ndarray_l_3d( flcl_ndarray_t *nd_array_l_3d, flcl::flcl_ndarray_index_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_l_3d = view_from_ndarray<bool***>(*nd_array_l_3d);
+    flcl::flcl_ndarray_index_c_t c_sum = 0;
+    auto array_l_3d = view_from_ndarray<flcl::flcl_ndarray_l_c_t***>(*nd_array_l_3d);
 
     for (size_t ii = 0; ii < array_l_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_l_3d.extent(1); jj++) {
@@ -502,11 +502,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i32_3d( flcl_ndarray_t *nd_array_i32_3d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i32_c_t c_test_ndarray_i32_3d( flcl_ndarray_t *nd_array_i32_3d, flcl::flcl_ndarray_i32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i32_3d = view_from_ndarray<int32_t***>(*nd_array_i32_3d);
+    flcl::flcl_ndarray_i32_c_t c_sum = 0;
+    auto array_i32_3d = view_from_ndarray<flcl::flcl_ndarray_i32_c_t***>(*nd_array_i32_3d);
 
     for (size_t ii = 0; ii < array_i32_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i32_3d.extent(1); jj++) {
@@ -536,11 +536,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i64_3d( flcl_ndarray_t *nd_array_i64_3d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i64_c_t c_test_ndarray_i64_3d( flcl_ndarray_t *nd_array_i64_3d, flcl::flcl_ndarray_i64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i64_3d = view_from_ndarray<int64_t***>(*nd_array_i64_3d);
+    flcl::flcl_ndarray_i64_c_t c_sum = 0;
+    auto array_i64_3d = view_from_ndarray<flcl::flcl_ndarray_i64_c_t***>(*nd_array_i64_3d);
 
     for (size_t ii = 0; ii < array_i64_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i64_3d.extent(1); jj++) {
@@ -570,11 +570,11 @@ extern "C" {
     return c_sum;
   }
 
-  float c_test_ndarray_r32_3d( flcl_ndarray_t *nd_array_r32_3d, float *f_sum ) {
+  flcl::flcl_ndarray_r32_c_t c_test_ndarray_r32_3d( flcl_ndarray_t *nd_array_r32_3d, flcl::flcl_ndarray_r32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    float c_sum = 0;
-    auto array_r32_3d = view_from_ndarray<float***>(*nd_array_r32_3d);
+    flcl::flcl_ndarray_r32_c_t c_sum = 0;
+    auto array_r32_3d = view_from_ndarray<flcl::flcl_ndarray_r32_c_t***>(*nd_array_r32_3d);
 
     for (size_t ii = 0; ii < array_r32_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r32_3d.extent(1); jj++) {
@@ -606,11 +606,11 @@ extern "C" {
     return c_sum;
   }
 
-  double c_test_ndarray_r64_3d( flcl_ndarray_t *nd_array_r64_3d, double *f_sum ) {
+  flcl::flcl_ndarray_r64_c_t c_test_ndarray_r64_3d( flcl_ndarray_t *nd_array_r64_3d, flcl::flcl_ndarray_r64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    double c_sum = 0;
-    auto array_r64_3d = view_from_ndarray<double***>(*nd_array_r64_3d);
+    flcl::flcl_ndarray_r64_c_t c_sum = 0;
+    auto array_r64_3d = view_from_ndarray<flcl::flcl_ndarray_r64_c_t***>(*nd_array_r64_3d);
 
     for (size_t ii = 0; ii < array_r64_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r64_3d.extent(1); jj++) {
@@ -643,12 +643,12 @@ extern "C" {
 
   }
 
-  std::complex<float> c_test_ndarray_c32_3d( flcl_ndarray_t *nd_array_c32_3d, std::complex<float> *f_sum ) {
+  flcl::flcl_ndarray_c32_c_t c_test_ndarray_c32_3d( flcl_ndarray_t *nd_array_c32_3d, flcl::flcl_ndarray_c32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
     
-    Kokkos::complex<float> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c32_3d = view_from_ndarray<Kokkos::complex<float>***>(*nd_array_c32_3d);
+    auto array_c32_3d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>***>(*nd_array_c32_3d);
     for (size_t ii = 0; ii < array_c32_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_3d.extent(2); kk++) {
@@ -671,11 +671,11 @@ extern "C" {
       exit(EXIT_FAILURE);
     }
 
-    c_sum = Kokkos::complex<float>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c32_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_3d.extent(2); kk++) {
-          array_c32_3d(ii,jj,kk) = Kokkos::complex<float>(1.0*(ii+jj+kk),-1.0*(ii+jj+kk));
+          array_c32_3d(ii,jj,kk) = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(1.0*(ii+jj+kk),-1.0*(ii+jj+kk));
           c_sum = c_sum + array_c32_3d(ii,jj,kk);
         }
       }
@@ -684,12 +684,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<double> c_test_ndarray_c64_3d( flcl_ndarray_t *nd_array_c64_3d, std::complex<double> *f_sum ) {
+  flcl::flcl_ndarray_c64_c_t c_test_ndarray_c64_3d( flcl_ndarray_t *nd_array_c64_3d, flcl::flcl_ndarray_c64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    Kokkos::complex<double> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c64_3d = view_from_ndarray<Kokkos::complex<double>***>(*nd_array_c64_3d);
+    auto array_c64_3d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>***>(*nd_array_c64_3d);
     for (size_t ii = 0; ii < array_c64_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_3d.extent(2); kk++) {
@@ -713,11 +713,11 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
     
-    c_sum = Kokkos::complex<double>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c64_3d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_3d.extent(2); kk++) {
-          array_c64_3d(ii,jj,kk) = Kokkos::complex<double>(1.0*(ii+jj+kk),-1.0*(ii+jj+kk));
+          array_c64_3d(ii,jj,kk) = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(1.0*(ii+jj+kk),-1.0*(ii+jj+kk));
           // c_sum = c_sum + array_c64_3d(ii,jj,kk);
           c_sum = c_sum + array_c64_3d(ii,jj,kk);
           // std::cout << "c ii "<< ii << " jj " << " kk " << kk << " c_sum " << c_sum << std::endl;
@@ -2028,7 +2028,7 @@ extern "C" {
     return c_sum;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_l_1d( flcl::view_l_1d_t **v_array_l_1d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_l_1d( flcl::view_l_1d_t **v_array_l_1d, flcl::flcl_view_index_c_t *f_sum, flcl::flcl_view_index_c_t *c_sum ) {
     *c_sum = 0;
     auto array_l_1d = **v_array_l_1d;
     for (size_t ii = 0; ii < array_l_1d.extent(0); ii++) {
@@ -2044,7 +2044,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i32_1d( flcl::view_i32_1d_t **v_array_i32_1d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i32_1d( flcl::view_i32_1d_t **v_array_i32_1d, flcl::flcl_view_i32_c_t *f_sum, flcl::flcl_view_i32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i32_1d = **v_array_i32_1d;
     for (size_t ii = 0; ii < array_i32_1d.extent(0); ii++) {
@@ -2062,7 +2062,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i64_1d( flcl::view_i64_1d_t **v_array_i64_1d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i64_1d( flcl::view_i64_1d_t **v_array_i64_1d, flcl::flcl_view_i64_c_t *f_sum, flcl::flcl_view_i64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i64_1d = **v_array_i64_1d;
     for (size_t ii = 0; ii < array_i64_1d.extent(0); ii++) {
@@ -2080,7 +2080,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r32_1d( flcl::view_r32_1d_t **v_array_r32_1d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r32_1d( flcl::view_r32_1d_t **v_array_r32_1d, flcl::flcl_view_r32_c_t *f_sum, flcl::flcl_view_r32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r32_1d = **v_array_r32_1d;
     for (size_t ii = 0; ii < array_r32_1d.extent(0); ii++) {
@@ -2098,7 +2098,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r64_1d( flcl::view_r64_1d_t **v_array_r64_1d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r64_1d( flcl::view_r64_1d_t **v_array_r64_1d, flcl::flcl_view_r64_c_t *f_sum, flcl::flcl_view_r64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r64_1d = **v_array_r64_1d;
     for (size_t ii = 0; ii < array_r64_1d.extent(0); ii++) {
@@ -2116,7 +2116,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_l_2d( flcl::view_l_2d_t **v_array_l_2d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_l_2d( flcl::view_l_2d_t **v_array_l_2d, flcl::flcl_view_index_c_t *f_sum, flcl::flcl_view_index_c_t *c_sum ) {
     *c_sum = 0;
     auto array_l_2d = **v_array_l_2d;
     for (size_t ii = 0; ii < array_l_2d.extent(0); ii++) {
@@ -2136,7 +2136,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i32_2d( flcl::view_i32_2d_t **v_array_i32_2d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i32_2d( flcl::view_i32_2d_t **v_array_i32_2d, flcl::flcl_view_i32_c_t *f_sum, flcl::flcl_view_i32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i32_2d = **v_array_i32_2d;
     for (size_t ii = 0; ii < array_i32_2d.extent(0); ii++) {
@@ -2158,7 +2158,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i64_2d( flcl::view_i64_2d_t **v_array_i64_2d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i64_2d( flcl::view_i64_2d_t **v_array_i64_2d, flcl::flcl_view_i64_c_t *f_sum, flcl::flcl_view_i64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i64_2d = **v_array_i64_2d;
     for (size_t ii = 0; ii < array_i64_2d.extent(0); ii++) {
@@ -2180,7 +2180,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r32_2d( flcl::view_r32_2d_t **v_array_r32_2d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r32_2d( flcl::view_r32_2d_t **v_array_r32_2d, flcl::flcl_view_r32_c_t *f_sum, flcl::flcl_view_r32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r32_2d = **v_array_r32_2d;
     for (size_t ii = 0; ii < array_r32_2d.extent(0); ii++) {
@@ -2202,7 +2202,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r64_2d( flcl::view_r64_2d_t **v_array_r64_2d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r64_2d( flcl::view_r64_2d_t **v_array_r64_2d, flcl::flcl_view_r64_c_t *f_sum, flcl::flcl_view_r64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r64_2d = **v_array_r64_2d;
     for (size_t ii = 0; ii < array_r64_2d.extent(0); ii++) {
@@ -2224,7 +2224,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_l_3d( flcl::view_l_3d_t **v_array_l_3d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_l_3d( flcl::view_l_3d_t **v_array_l_3d, flcl::flcl_view_index_c_t *f_sum, flcl::flcl_view_index_c_t *c_sum ) {
     *c_sum = 0;
     auto array_l_3d = **v_array_l_3d;
     for (size_t ii = 0; ii < array_l_3d.extent(0); ii++) {
@@ -2248,7 +2248,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i32_3d( flcl::view_i32_3d_t **v_array_i32_3d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i32_3d( flcl::view_i32_3d_t **v_array_i32_3d, flcl::flcl_view_i32_c_t *f_sum, flcl::flcl_view_i32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i32_3d = **v_array_i32_3d;
     for (size_t ii = 0; ii < array_i32_3d.extent(0); ii++) {
@@ -2274,7 +2274,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i64_3d( flcl::view_i64_3d_t **v_array_i64_3d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i64_3d( flcl::view_i64_3d_t **v_array_i64_3d, flcl::flcl_view_i64_c_t *f_sum, flcl::flcl_view_i64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i64_3d = **v_array_i64_3d;
     for (size_t ii = 0; ii < array_i64_3d.extent(0); ii++) {
@@ -2300,7 +2300,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r32_3d( flcl::view_r32_3d_t **v_array_r32_3d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r32_3d( flcl::view_r32_3d_t **v_array_r32_3d, flcl::flcl_view_r32_c_t *f_sum, flcl::flcl_view_r32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r32_3d = **v_array_r32_3d;
     for (size_t ii = 0; ii < array_r32_3d.extent(0); ii++) {
@@ -2326,7 +2326,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r64_3d( flcl::view_r64_3d_t **v_array_r64_3d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r64_3d( flcl::view_r64_3d_t **v_array_r64_3d, flcl::flcl_view_r64_c_t *f_sum, flcl::flcl_view_r64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r64_3d = **v_array_r64_3d;
     for (size_t ii = 0; ii < array_r64_3d.extent(0); ii++) {
@@ -2353,7 +2353,7 @@ extern "C" {
 
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_l_4d( flcl::view_l_4d_t **v_array_l_4d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_l_4d( flcl::view_l_4d_t **v_array_l_4d, flcl::flcl_view_index_c_t *f_sum, flcl::flcl_view_index_c_t *c_sum ) {
     *c_sum = 0;
     auto array_l_4d = **v_array_l_4d;
     for (size_t ii = 0; ii < array_l_4d.extent(0); ii++) {
@@ -2381,7 +2381,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i32_4d( flcl::view_i32_4d_t **v_array_i32_4d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i32_4d( flcl::view_i32_4d_t **v_array_i32_4d, flcl::flcl_view_i32_c_t *f_sum, flcl::flcl_view_i32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i32_4d = **v_array_i32_4d;
     for (size_t ii = 0; ii < array_i32_4d.extent(0); ii++) {
@@ -2411,7 +2411,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i64_4d( flcl::view_i64_4d_t **v_array_i64_4d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i64_4d( flcl::view_i64_4d_t **v_array_i64_4d, flcl::flcl_view_i64_c_t *f_sum, flcl::flcl_view_i64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i64_4d = **v_array_i64_4d;
     for (size_t ii = 0; ii < array_i64_4d.extent(0); ii++) {
@@ -2441,7 +2441,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r32_4d( flcl::view_r32_4d_t **v_array_r32_4d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r32_4d( flcl::view_r32_4d_t **v_array_r32_4d, flcl::flcl_view_r32_c_t *f_sum, flcl::flcl_view_r32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r32_4d = **v_array_r32_4d;
     for (size_t ii = 0; ii < array_r32_4d.extent(0); ii++) {
@@ -2471,7 +2471,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r64_4d( flcl::view_r64_4d_t **v_array_r64_4d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r64_4d( flcl::view_r64_4d_t **v_array_r64_4d, flcl::flcl_view_r64_c_t *f_sum, flcl::flcl_view_r64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r64_4d = **v_array_r64_4d;
     for (size_t ii = 0; ii < array_r64_4d.extent(0); ii++) {
@@ -2502,7 +2502,7 @@ extern "C" {
 
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_l_5d( flcl::view_l_5d_t **v_array_l_5d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_l_5d( flcl::view_l_5d_t **v_array_l_5d, flcl::flcl_view_index_c_t *f_sum, flcl::flcl_view_index_c_t *c_sum ) {
     *c_sum = 0;
     auto array_l_5d = **v_array_l_5d;
     for (size_t ii = 0; ii < array_l_5d.extent(0); ii++) {
@@ -2534,7 +2534,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i32_5d( flcl::view_i32_5d_t **v_array_i32_5d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i32_5d( flcl::view_i32_5d_t **v_array_i32_5d, flcl::flcl_view_i32_c_t *f_sum, flcl::flcl_view_i32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i32_5d = **v_array_i32_5d;
     for (size_t ii = 0; ii < array_i32_5d.extent(0); ii++) {
@@ -2568,7 +2568,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i64_5d( flcl::view_i64_5d_t **v_array_i64_5d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i64_5d( flcl::view_i64_5d_t **v_array_i64_5d, flcl::flcl_view_i64_c_t *f_sum, flcl::flcl_view_i64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i64_5d = **v_array_i64_5d;
     for (size_t ii = 0; ii < array_i64_5d.extent(0); ii++) {
@@ -2602,7 +2602,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r32_5d( flcl::view_r32_5d_t **v_array_r32_5d, float *f_sum, float *c_sum ){
+  flcl_test_error_t c_test_kokkos_allocate_view_r32_5d( flcl::view_r32_5d_t **v_array_r32_5d, flcl::flcl_view_r32_c_t *f_sum, flcl::flcl_view_r32_c_t *c_sum ){
     *c_sum = 0;
     auto array_r32_5d = **v_array_r32_5d;
     for (size_t ii = 0; ii < array_r32_5d.extent(0); ii++) {
@@ -2636,7 +2636,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r64_5d( flcl::view_r64_5d_t **v_array_r64_5d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r64_5d( flcl::view_r64_5d_t **v_array_r64_5d, flcl::flcl_view_r64_c_t *f_sum, flcl::flcl_view_r64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r64_5d = **v_array_r64_5d;
     for (size_t ii = 0; ii < array_r64_5d.extent(0); ii++) {
@@ -2671,7 +2671,7 @@ extern "C" {
 
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_l_6d( flcl::view_l_6d_t **v_array_l_6d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_l_6d( flcl::view_l_6d_t **v_array_l_6d, flcl::flcl_view_index_c_t *f_sum, flcl::flcl_view_index_c_t *c_sum ) {
     *c_sum = 0;
     auto array_l_6d = **v_array_l_6d;
     for (size_t ii = 0; ii < array_l_6d.extent(0); ii++) {
@@ -2707,7 +2707,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i32_6d( flcl::view_i32_6d_t **v_array_i32_6d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i32_6d( flcl::view_i32_6d_t **v_array_i32_6d, flcl::flcl_view_i32_c_t *f_sum, flcl::flcl_view_i32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i32_6d = **v_array_i32_6d;
     for (size_t ii = 0; ii < array_i32_6d.extent(0); ii++) {
@@ -2745,7 +2745,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i64_6d( flcl::view_i64_6d_t **v_array_i64_6d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i64_6d( flcl::view_i64_6d_t **v_array_i64_6d, flcl::flcl_view_i64_c_t *f_sum, flcl::flcl_view_i64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i64_6d = **v_array_i64_6d;
     for (size_t ii = 0; ii < array_i64_6d.extent(0); ii++) {
@@ -2783,7 +2783,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r32_6d( flcl::view_r32_6d_t **v_array_r32_6d, float *f_sum, float *c_sum ){
+  flcl_test_error_t c_test_kokkos_allocate_view_r32_6d( flcl::view_r32_6d_t **v_array_r32_6d, flcl::flcl_view_r32_c_t *f_sum, flcl::flcl_view_r32_c_t *c_sum ){
     *c_sum = 0;
     auto array_r32_6d = **v_array_r32_6d;
     for (size_t ii = 0; ii < array_r32_6d.extent(0); ii++) {
@@ -2821,7 +2821,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r64_6d( flcl::view_r64_6d_t **v_array_r64_6d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r64_6d( flcl::view_r64_6d_t **v_array_r64_6d, flcl::flcl_view_r64_c_t *f_sum, flcl::flcl_view_r64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r64_6d = **v_array_r64_6d;
     for (size_t ii = 0; ii < array_r64_6d.extent(0); ii++) {
@@ -2860,7 +2860,7 @@ extern "C" {
 
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_l_7d( flcl::view_l_7d_t **v_array_l_7d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_l_7d( flcl::view_l_7d_t **v_array_l_7d, flcl::flcl_view_index_c_t *f_sum, flcl::flcl_view_index_c_t *c_sum ) {
     *c_sum = 0;
     auto array_l_7d = **v_array_l_7d;
     for (size_t ii = 0; ii < array_l_7d.extent(0); ii++) {
@@ -2900,7 +2900,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i32_7d( flcl::view_i32_7d_t **v_array_i32_7d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i32_7d( flcl::view_i32_7d_t **v_array_i32_7d, flcl::flcl_view_i32_c_t *f_sum, flcl::flcl_view_i32_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i32_7d = **v_array_i32_7d;
     for (size_t ii = 0; ii < array_i32_7d.extent(0); ii++) {
@@ -2942,7 +2942,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_i64_7d( flcl::view_i64_7d_t **v_array_i64_7d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_i64_7d( flcl::view_i64_7d_t **v_array_i64_7d, flcl::flcl_view_i64_c_t *f_sum, flcl::flcl_view_i64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_i64_7d = **v_array_i64_7d;
     for (size_t ii = 0; ii < array_i64_7d.extent(0); ii++) {
@@ -2984,7 +2984,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r32_7d( flcl::view_r32_7d_t **v_array_r32_7d, float *f_sum, float *c_sum ){
+  flcl_test_error_t c_test_kokkos_allocate_view_r32_7d( flcl::view_r32_7d_t **v_array_r32_7d, flcl::flcl_view_r32_c_t *f_sum, flcl::flcl_view_r32_c_t *c_sum ){
     *c_sum = 0;
     auto array_r32_7d = **v_array_r32_7d;
     for (size_t ii = 0; ii < array_r32_7d.extent(0); ii++) {
@@ -3026,7 +3026,7 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_view_r64_7d( flcl::view_r64_7d_t **v_array_r64_7d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_view_r64_7d( flcl::view_r64_7d_t **v_array_r64_7d, flcl::flcl_view_r64_c_t *f_sum, flcl::flcl_view_r64_c_t *c_sum ) {
     *c_sum = 0;
     auto array_r64_7d = **v_array_r64_7d;
     for (size_t ii = 0; ii < array_r64_7d.extent(0); ii++) {
@@ -3406,13 +3406,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     return FLCL_TEST_PASS;
   }
 
-flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **v_array_l_3d, size_t *f_sum, size_t *c_sum ) {
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **v_array_l_3d, flcl::flcl_dualview_index_c_t *f_sum, flcl::flcl_dualview_index_c_t *c_sum ) {
     using view_type = flcl::dualview_l_3d_t;
     *c_sum = 0;
     auto array_l_3d = **v_array_l_3d;
     array_l_3d.template modify<typename view_type::host_mirror_space>();
     array_l_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_3d_get", array_l_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_3d_get", array_l_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_index_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_l_3d.extent(1); jj++) { 
         for (size_t kk = 0; kk < array_l_3d.extent(2); kk++) {
@@ -3445,13 +3445,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_3d( flcl::dualview_i32_3d_t **v_array_i32_3d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_3d( flcl::dualview_i32_3d_t **v_array_i32_3d, flcl::flcl_dualview_i32_c_t *f_sum, flcl::flcl_dualview_i32_c_t *c_sum ) {
     using view_type = flcl::dualview_i32_3d_t;
     *c_sum = 0;
     auto array_i32_3d = **v_array_i32_3d;
     array_i32_3d.template modify<typename view_type::host_mirror_space>();
     array_i32_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_3d_get", array_i32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_3d_get", array_i32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_3d.extent(2); kk++) {
@@ -3470,7 +3470,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     *c_sum = 0;
     array_i32_3d.template modify<typename view_type::host_mirror_space>();
     array_i32_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_3d_set", array_i32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_3d_set", array_i32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_3d.extent(2); kk++) {
@@ -3485,13 +3485,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_3d( flcl::dualview_i64_3d_t **v_array_i64_3d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_3d( flcl::dualview_i64_3d_t **v_array_i64_3d, flcl::flcl_dualview_i64_c_t *f_sum, flcl::flcl_dualview_i64_c_t *c_sum ) {
     using view_type = flcl::dualview_i64_3d_t;
     *c_sum = 0;
     auto array_i64_3d = **v_array_i64_3d;
     array_i64_3d.template modify<typename view_type::host_mirror_space>();
     array_i64_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_3d_get", array_i64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_3d_get", array_i64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_3d.extent(2); kk++) {
@@ -3510,7 +3510,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     *c_sum = 0;
     array_i64_3d.template modify<typename view_type::host_mirror_space>();
     array_i64_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_3d_set", array_i64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_3d_set", array_i64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_3d.extent(2); kk++) {
@@ -3525,13 +3525,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_3d( flcl::dualview_r32_3d_t **v_array_r32_3d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_3d( flcl::dualview_r32_3d_t **v_array_r32_3d, flcl::flcl_dualview_r32_c_t *f_sum, flcl::flcl_dualview_r32_c_t *c_sum ) {
     using view_type = flcl::dualview_r32_3d_t;
     *c_sum = 0;
     auto array_r32_3d = **v_array_r32_3d;
     array_r32_3d.template modify<typename view_type::host_mirror_space>();
     array_r32_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_3d_get", array_r32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_3d_get", array_r32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_3d.extent(2); kk++) {
@@ -3550,7 +3550,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     *c_sum = 0;
     array_r32_3d.template modify<typename view_type::host_mirror_space>();
     array_r32_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_3d_set", array_r32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_3d_set", array_r32_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_3d.extent(2); kk++) {
@@ -3565,13 +3565,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_3d( flcl::dualview_r64_3d_t **v_array_r64_3d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_3d( flcl::dualview_r64_3d_t **v_array_r64_3d, flcl::flcl_dualview_r64_c_t *f_sum, flcl::flcl_dualview_r64_c_t *c_sum ) {
     using view_type = flcl::dualview_r64_3d_t;
     *c_sum = 0;
     auto array_r64_3d = **v_array_r64_3d;
     array_r64_3d.template modify<typename view_type::host_mirror_space>();
     array_r64_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_3d_get", array_r64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_3d_get", array_r64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_3d.extent(2); kk++) {
@@ -3590,7 +3590,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     *c_sum = 0;
     array_r64_3d.template modify<typename view_type::host_mirror_space>();
     array_r64_3d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_3d_set", array_r64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_3d_set", array_r64_3d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_3d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_3d.extent(2); kk++) {
@@ -3605,13 +3605,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_3d( flcl::dualview_l_3d_t **
     return FLCL_TEST_PASS;
   }
 
-flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **v_array_l_4d, size_t *f_sum, size_t *c_sum ) {
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **v_array_l_4d, flcl::flcl_dualview_index_c_t *f_sum, flcl::flcl_dualview_index_c_t *c_sum ) {
     using view_type = flcl::dualview_l_4d_t;
     *c_sum = 0;
     auto array_l_4d = **v_array_l_4d;
     array_l_4d.template modify<typename view_type::host_mirror_space>();
     array_l_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_4d_get", array_l_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_4d_get", array_l_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_index_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_l_4d.extent(1); jj++) { 
         for (size_t kk = 0; kk < array_l_4d.extent(2); kk++) {
@@ -3648,13 +3648,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_4d( flcl::dualview_i32_4d_t **v_array_i32_4d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_4d( flcl::dualview_i32_4d_t **v_array_i32_4d, flcl::flcl_dualview_i32_c_t *f_sum, flcl::flcl_dualview_i32_c_t *c_sum ) {
     using view_type = flcl::dualview_i32_4d_t;
     *c_sum = 0;
     auto array_i32_4d = **v_array_i32_4d;
     array_i32_4d.template modify<typename view_type::host_mirror_space>();
     array_i32_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_4d_get", array_i32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_4d_get", array_i32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_4d.extent(2); kk++) {
@@ -3675,7 +3675,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     *c_sum = 0;
     array_i32_4d.template modify<typename view_type::host_mirror_space>();
     array_i32_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_4d_set", array_i32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_4d_set", array_i32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_4d.extent(2); kk++) {
@@ -3692,13 +3692,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_4d( flcl::dualview_i64_4d_t **v_array_i64_4d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_4d( flcl::dualview_i64_4d_t **v_array_i64_4d, flcl::flcl_dualview_i64_c_t *f_sum, flcl::flcl_dualview_i64_c_t *c_sum ) {
     using view_type = flcl::dualview_i64_4d_t;
     *c_sum = 0;
     auto array_i64_4d = **v_array_i64_4d;
     array_i64_4d.template modify<typename view_type::host_mirror_space>();
     array_i64_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_4d_get", array_i64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_4d_get", array_i64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_4d.extent(2); kk++) {
@@ -3719,7 +3719,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     *c_sum = 0;
     array_i64_4d.template modify<typename view_type::host_mirror_space>();
     array_i64_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_4d_set", array_i64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_4d_set", array_i64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_4d.extent(2); kk++) {
@@ -3736,13 +3736,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_4d( flcl::dualview_r32_4d_t **v_array_r32_4d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_4d( flcl::dualview_r32_4d_t **v_array_r32_4d, flcl::flcl_dualview_r32_c_t *f_sum, flcl::flcl_dualview_r32_c_t *c_sum ) {
     using view_type = flcl::dualview_r32_4d_t;
     *c_sum = 0;
     auto array_r32_4d = **v_array_r32_4d;
     array_r32_4d.template modify<typename view_type::host_mirror_space>();
     array_r32_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_4d_get", array_r32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_4d_get", array_r32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_4d.extent(2); kk++) {
@@ -3763,7 +3763,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     *c_sum = 0;
     array_r32_4d.template modify<typename view_type::host_mirror_space>();
     array_r32_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_4d_set", array_r32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_4d_set", array_r32_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_4d.extent(2); kk++) {
@@ -3780,13 +3780,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_4d( flcl::dualview_r64_4d_t **v_array_r64_4d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_4d( flcl::dualview_r64_4d_t **v_array_r64_4d, flcl::flcl_dualview_r64_c_t *f_sum, flcl::flcl_dualview_r64_c_t *c_sum ) {
     using view_type = flcl::dualview_r64_4d_t;
     *c_sum = 0;
     auto array_r64_4d = **v_array_r64_4d;
     array_r64_4d.template modify<typename view_type::host_mirror_space>();
     array_r64_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_4d_get", array_r64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_4d_get", array_r64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_4d.extent(2); kk++) {
@@ -3807,7 +3807,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     *c_sum = 0;
     array_r64_4d.template modify<typename view_type::host_mirror_space>();
     array_r64_4d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_4d_set", array_r64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_4d_set", array_r64_4d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_4d.extent(2); kk++) {
@@ -3824,13 +3824,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_4d( flcl::dualview_l_4d_t **
     return FLCL_TEST_PASS;
   }
 
-flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **v_array_l_5d, size_t *f_sum, size_t *c_sum ) {
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **v_array_l_5d, flcl::flcl_dualview_index_c_t *f_sum, flcl::flcl_dualview_index_c_t *c_sum ) {
     using view_type = flcl::dualview_l_5d_t;
     *c_sum = 0;
     auto array_l_5d = **v_array_l_5d;
     array_l_5d.template modify<typename view_type::host_mirror_space>();
     array_l_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_5d_get", array_l_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_5d_get", array_l_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_index_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_l_5d.extent(1); jj++) { 
         for (size_t kk = 0; kk < array_l_5d.extent(2); kk++) {
@@ -3871,13 +3871,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_5d( flcl::dualview_i32_5d_t **v_array_i32_5d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_5d( flcl::dualview_i32_5d_t **v_array_i32_5d, flcl::flcl_dualview_i32_c_t *f_sum, flcl::flcl_dualview_i32_c_t *c_sum ) {
     using view_type = flcl::dualview_i32_5d_t;
     *c_sum = 0;
     auto array_i32_5d = **v_array_i32_5d;
     array_i32_5d.template modify<typename view_type::host_mirror_space>();
     array_i32_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_5d_get", array_i32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_5d_get", array_i32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_5d.extent(2); kk++) {
@@ -3900,7 +3900,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     *c_sum = 0;
     array_i32_5d.template modify<typename view_type::host_mirror_space>();
     array_i32_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_5d_set", array_i32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_5d_set", array_i32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_5d.extent(2); kk++) {
@@ -3919,13 +3919,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_5d( flcl::dualview_i64_5d_t **v_array_i64_5d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_5d( flcl::dualview_i64_5d_t **v_array_i64_5d, flcl::flcl_dualview_i64_c_t *f_sum, flcl::flcl_dualview_i64_c_t *c_sum ) {
     using view_type = flcl::dualview_i64_5d_t;
     *c_sum = 0;
     auto array_i64_5d = **v_array_i64_5d;
     array_i64_5d.template modify<typename view_type::host_mirror_space>();
     array_i64_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_5d_get", array_i64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_5d_get", array_i64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_5d.extent(2); kk++) {
@@ -3948,7 +3948,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     *c_sum = 0;
     array_i64_5d.template modify<typename view_type::host_mirror_space>();
     array_i64_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_5d_set", array_i64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_5d_set", array_i64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_5d.extent(2); kk++) {
@@ -3967,13 +3967,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_5d( flcl::dualview_r32_5d_t **v_array_r32_5d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_5d( flcl::dualview_r32_5d_t **v_array_r32_5d, flcl::flcl_dualview_r32_c_t *f_sum, flcl::flcl_dualview_r32_c_t *c_sum ) {
     using view_type = flcl::dualview_r32_5d_t;
     *c_sum = 0;
     auto array_r32_5d = **v_array_r32_5d;
     array_r32_5d.template modify<typename view_type::host_mirror_space>();
     array_r32_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_5d_get", array_r32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_5d_get", array_r32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_5d.extent(2); kk++) {
@@ -3996,7 +3996,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     *c_sum = 0;
     array_r32_5d.template modify<typename view_type::host_mirror_space>();
     array_r32_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_5d_set", array_r32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_5d_set", array_r32_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_5d.extent(2); kk++) {
@@ -4015,13 +4015,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_5d( flcl::dualview_r64_5d_t **v_array_r64_5d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_5d( flcl::dualview_r64_5d_t **v_array_r64_5d, flcl::flcl_dualview_r64_c_t *f_sum, flcl::flcl_dualview_r64_c_t *c_sum ) {
     using view_type = flcl::dualview_r64_5d_t;
     *c_sum = 0;
     auto array_r64_5d = **v_array_r64_5d;
     array_r64_5d.template modify<typename view_type::host_mirror_space>();
     array_r64_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_5d_get", array_r64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_5d_get", array_r64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_5d.extent(2); kk++) {
@@ -4044,7 +4044,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     *c_sum = 0;
     array_r64_5d.template modify<typename view_type::host_mirror_space>();
     array_r64_5d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_5d_set", array_r64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_5d_set", array_r64_5d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_5d.extent(2); kk++) {
@@ -4063,13 +4063,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_5d( flcl::dualview_l_5d_t **
     return FLCL_TEST_PASS;
   }
 
-flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **v_array_l_6d, size_t *f_sum, size_t *c_sum ) {
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **v_array_l_6d, flcl::flcl_dualview_index_c_t *f_sum, flcl::flcl_dualview_index_c_t *c_sum ) {
     using view_type = flcl::dualview_l_6d_t;
     *c_sum = 0;
     auto array_l_6d = **v_array_l_6d;
     array_l_6d.template modify<typename view_type::host_mirror_space>();
     array_l_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_6d_get", array_l_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_6d_get", array_l_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_index_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_l_6d.extent(1); jj++) { 
         for (size_t kk = 0; kk < array_l_6d.extent(2); kk++) {
@@ -4114,13 +4114,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_6d( flcl::dualview_i32_6d_t **v_array_i32_6d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_6d( flcl::dualview_i32_6d_t **v_array_i32_6d, flcl::flcl_dualview_i32_c_t *f_sum, flcl::flcl_dualview_i32_c_t *c_sum ) {
     using view_type = flcl::dualview_i32_6d_t;
     *c_sum = 0;
     auto array_i32_6d = **v_array_i32_6d;
     array_i32_6d.template modify<typename view_type::host_mirror_space>();
     array_i32_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_6d_get", array_i32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_6d_get", array_i32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_6d.extent(2); kk++) {
@@ -4145,7 +4145,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     *c_sum = 0;
     array_i32_6d.template modify<typename view_type::host_mirror_space>();
     array_i32_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_6d_set", array_i32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_6d_set", array_i32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_6d.extent(2); kk++) {
@@ -4166,13 +4166,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_6d( flcl::dualview_i64_6d_t **v_array_i64_6d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_6d( flcl::dualview_i64_6d_t **v_array_i64_6d, flcl::flcl_dualview_i64_c_t *f_sum, flcl::flcl_dualview_i64_c_t *c_sum ) {
     using view_type = flcl::dualview_i64_6d_t;
     *c_sum = 0;
     auto array_i64_6d = **v_array_i64_6d;
     array_i64_6d.template modify<typename view_type::host_mirror_space>();
     array_i64_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_6d_get", array_i64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_6d_get", array_i64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_6d.extent(2); kk++) {
@@ -4197,7 +4197,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     *c_sum = 0;
     array_i64_6d.template modify<typename view_type::host_mirror_space>();
     array_i64_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_6d_set", array_i64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_6d_set", array_i64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_6d.extent(2); kk++) {
@@ -4218,13 +4218,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_6d( flcl::dualview_r32_6d_t **v_array_r32_6d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_6d( flcl::dualview_r32_6d_t **v_array_r32_6d, flcl::flcl_dualview_r32_c_t *f_sum, flcl::flcl_dualview_r32_c_t *c_sum ) {
     using view_type = flcl::dualview_r32_6d_t;
     *c_sum = 0;
     auto array_r32_6d = **v_array_r32_6d;
     array_r32_6d.template modify<typename view_type::host_mirror_space>();
     array_r32_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_6d_get", array_r32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_6d_get", array_r32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_6d.extent(2); kk++) {
@@ -4249,7 +4249,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     *c_sum = 0;
     array_r32_6d.template modify<typename view_type::host_mirror_space>();
     array_r32_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_6d_set", array_r32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_6d_set", array_r32_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_6d.extent(2); kk++) {
@@ -4270,13 +4270,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_6d( flcl::dualview_r64_6d_t **v_array_r64_6d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_6d( flcl::dualview_r64_6d_t **v_array_r64_6d, flcl::flcl_dualview_r64_c_t *f_sum, flcl::flcl_dualview_r64_c_t *c_sum ) {
     using view_type = flcl::dualview_r64_6d_t;
     *c_sum = 0;
     auto array_r64_6d = **v_array_r64_6d;
     array_r64_6d.template modify<typename view_type::host_mirror_space>();
     array_r64_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_6d_get", array_r64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_6d_get", array_r64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_6d.extent(2); kk++) {
@@ -4301,7 +4301,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     *c_sum = 0;
     array_r64_6d.template modify<typename view_type::host_mirror_space>();
     array_r64_6d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_6d_set", array_r64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_6d_set", array_r64_6d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_6d.extent(2); kk++) {
@@ -4322,13 +4322,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_6d( flcl::dualview_l_6d_t **
     return FLCL_TEST_PASS;
   }
 
-flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **v_array_l_7d, size_t *f_sum, size_t *c_sum ) {
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **v_array_l_7d, flcl::flcl_dualview_index_c_t *f_sum, flcl::flcl_dualview_index_c_t *c_sum ) {
     using view_type = flcl::dualview_l_7d_t;
     *c_sum = 0;
     auto array_l_7d = **v_array_l_7d;
     array_l_7d.template modify<typename view_type::host_mirror_space>();
     array_l_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_7d_get", array_l_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_7d_get", array_l_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_index_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_l_7d.extent(1); jj++) { 
         for (size_t kk = 0; kk < array_l_7d.extent(2); kk++) {
@@ -4377,13 +4377,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_7d( flcl::dualview_i32_7d_t **v_array_i32_7d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_7d( flcl::dualview_i32_7d_t **v_array_i32_7d, flcl::flcl_dualview_i32_c_t *f_sum, flcl::flcl_dualview_i32_c_t *c_sum ) {
     using view_type = flcl::dualview_i32_7d_t;
     *c_sum = 0;
     auto array_i32_7d = **v_array_i32_7d;
     array_i32_7d.template modify<typename view_type::host_mirror_space>();
     array_i32_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_7d_get", array_i32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_7d_get", array_i32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_7d.extent(2); kk++) {
@@ -4410,7 +4410,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     *c_sum = 0;
     array_i32_7d.template modify<typename view_type::host_mirror_space>();
     array_i32_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_7d_set", array_i32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_7d_set", array_i32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i32_7d.extent(2); kk++) {
@@ -4433,13 +4433,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_7d( flcl::dualview_i64_7d_t **v_array_i64_7d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_7d( flcl::dualview_i64_7d_t **v_array_i64_7d, flcl::flcl_dualview_i64_c_t *f_sum, flcl::flcl_dualview_i64_c_t *c_sum ) {
     using view_type = flcl::dualview_i64_7d_t;
     *c_sum = 0;
     auto array_i64_7d = **v_array_i64_7d;
     array_i64_7d.template modify<typename view_type::host_mirror_space>();
     array_i64_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_7d_get", array_i64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_7d_get", array_i64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_7d.extent(2); kk++) {
@@ -4466,7 +4466,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     *c_sum = 0;
     array_i64_7d.template modify<typename view_type::host_mirror_space>();
     array_i64_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_7d_set", array_i64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_7d_set", array_i64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_i64_7d.extent(2); kk++) {
@@ -4489,13 +4489,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_7d( flcl::dualview_r32_7d_t **v_array_r32_7d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_7d( flcl::dualview_r32_7d_t **v_array_r32_7d, flcl::flcl_dualview_r32_c_t *f_sum, flcl::flcl_dualview_r32_c_t *c_sum ) {
     using view_type = flcl::dualview_r32_7d_t;
     *c_sum = 0;
     auto array_r32_7d = **v_array_r32_7d;
     array_r32_7d.template modify<typename view_type::host_mirror_space>();
     array_r32_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_7d_get", array_r32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_7d_get", array_r32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_7d.extent(2); kk++) {
@@ -4522,7 +4522,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     *c_sum = 0;
     array_r32_7d.template modify<typename view_type::host_mirror_space>();
     array_r32_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_7d_set", array_r32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_7d_set", array_r32_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r32_7d.extent(2); kk++) {
@@ -4545,13 +4545,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_7d( flcl::dualview_r64_7d_t **v_array_r64_7d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_7d( flcl::dualview_r64_7d_t **v_array_r64_7d, flcl::flcl_dualview_r64_c_t *f_sum, flcl::flcl_dualview_r64_c_t *c_sum ) {
     using view_type = flcl::dualview_r64_7d_t;
     *c_sum = 0;
     auto array_r64_7d = **v_array_r64_7d;
     array_r64_7d.template modify<typename view_type::host_mirror_space>();
     array_r64_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_7d_get", array_r64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_7d_get", array_r64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_7d.extent(2); kk++) {
@@ -4578,7 +4578,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_7d( flcl::dualview_l_7d_t **
     *c_sum = 0;
     array_r64_7d.template modify<typename view_type::host_mirror_space>();
     array_r64_7d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_7d_set", array_r64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_7d_set", array_r64_7d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_r64_7d.extent(2); kk++) {

--- a/test/flcl-test-cxx.cpp
+++ b/test/flcl-test-cxx.cpp
@@ -41,6 +41,7 @@
 #include <iostream>
 #include <iomanip>
 #include <complex>
+#include "flcl-types-cxx.hpp"
 
 extern "C" {
 

--- a/test/flcl-test-cxx.cpp
+++ b/test/flcl-test-cxx.cpp
@@ -728,11 +728,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_l_4d( flcl_ndarray_t *nd_array_l_4d, size_t *f_sum ) {
+  flcl::flcl_ndarray_index_c_t c_test_ndarray_l_4d( flcl_ndarray_t *nd_array_l_4d, flcl::flcl_ndarray_index_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_l_4d = view_from_ndarray<bool****>(*nd_array_l_4d);
+    flcl::flcl_ndarray_index_c_t c_sum = 0;
+    auto array_l_4d = view_from_ndarray<flcl::flcl_ndarray_l_c_t****>(*nd_array_l_4d);
 
     for (size_t ii = 0; ii < array_l_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_l_4d.extent(1); jj++) {
@@ -764,11 +764,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i32_4d( flcl_ndarray_t *nd_array_i32_4d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i32_c_t c_test_ndarray_i32_4d( flcl_ndarray_t *nd_array_i32_4d, flcl::flcl_ndarray_i32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i32_4d = view_from_ndarray<int32_t****>(*nd_array_i32_4d);
+    flcl::flcl_ndarray_i32_c_t c_sum = 0;
+    auto array_i32_4d = view_from_ndarray<flcl::flcl_ndarray_i32_c_t****>(*nd_array_i32_4d);
 
     for (size_t ii = 0; ii < array_i32_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i32_4d.extent(1); jj++) {
@@ -802,11 +802,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i64_4d( flcl_ndarray_t *nd_array_i64_4d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i64_c_t c_test_ndarray_i64_4d( flcl_ndarray_t *nd_array_i64_4d, flcl::flcl_ndarray_i64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i64_4d = view_from_ndarray<int64_t****>(*nd_array_i64_4d);
+    flcl::flcl_ndarray_i64_c_t c_sum = 0;
+    auto array_i64_4d = view_from_ndarray<flcl::flcl_ndarray_i64_c_t****>(*nd_array_i64_4d);
 
     for (size_t ii = 0; ii < array_i64_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i64_4d.extent(1); jj++) {
@@ -840,11 +840,11 @@ extern "C" {
     return c_sum;
   }
 
-  float c_test_ndarray_r32_4d( flcl_ndarray_t *nd_array_r32_4d, float *f_sum ) {
+  flcl::flcl_ndarray_r32_c_t c_test_ndarray_r32_4d( flcl_ndarray_t *nd_array_r32_4d, flcl::flcl_ndarray_r32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    float c_sum = 0;
-    auto array_r32_4d = view_from_ndarray<float****>(*nd_array_r32_4d);
+    flcl::flcl_ndarray_r32_c_t c_sum = 0;
+    auto array_r32_4d = view_from_ndarray<flcl::flcl_ndarray_r32_c_t****>(*nd_array_r32_4d);
 
     for (size_t ii = 0; ii < array_r32_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r32_4d.extent(1); jj++) {
@@ -880,11 +880,11 @@ extern "C" {
     return c_sum;
   }
 
-  double c_test_ndarray_r64_4d( flcl_ndarray_t *nd_array_r64_4d, double *f_sum ) {
+  flcl::flcl_ndarray_r64_c_t c_test_ndarray_r64_4d( flcl_ndarray_t *nd_array_r64_4d, flcl::flcl_ndarray_r64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    double c_sum = 0;
-    auto array_r64_4d = view_from_ndarray<double****>(*nd_array_r64_4d);
+    flcl::flcl_ndarray_r64_c_t c_sum = 0;
+    auto array_r64_4d = view_from_ndarray<flcl::flcl_ndarray_r64_c_t****>(*nd_array_r64_4d);
 
     for (size_t ii = 0; ii < array_r64_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r64_4d.extent(1); jj++) {
@@ -921,12 +921,12 @@ extern "C" {
 
   }
 
-  std::complex<float> c_test_ndarray_c32_4d( flcl_ndarray_t *nd_array_c32_4d, std::complex<float> *f_sum ) {
+  flcl::flcl_ndarray_c32_c_t c_test_ndarray_c32_4d( flcl_ndarray_t *nd_array_c32_4d, flcl::flcl_ndarray_c32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
     
-    Kokkos::complex<float> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c32_4d = view_from_ndarray<Kokkos::complex<float>****>(*nd_array_c32_4d);
+    auto array_c32_4d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>****>(*nd_array_c32_4d);
     for (size_t ii = 0; ii < array_c32_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_4d.extent(2); kk++) {
@@ -951,12 +951,12 @@ extern "C" {
       exit(EXIT_FAILURE);
     }
 
-    c_sum = Kokkos::complex<float>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c32_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_4d.extent(2); kk++) {
           for (size_t ll = 0; ll < array_c32_4d.extent(3); ll++) {
-            array_c32_4d(ii,jj,kk,ll) = Kokkos::complex<float>(1.0*(ii+jj+kk+ll),-1.0*(ii+jj+kk+ll));
+            array_c32_4d(ii,jj,kk,ll) = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(1.0*(ii+jj+kk+ll),-1.0*(ii+jj+kk+ll));
             c_sum = c_sum + array_c32_4d(ii,jj,kk,ll);
           }
         }
@@ -966,12 +966,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<double> c_test_ndarray_c64_4d( flcl_ndarray_t *nd_array_c64_4d, std::complex<double> *f_sum ) {
+  flcl::flcl_ndarray_c64_c_t c_test_ndarray_c64_4d( flcl_ndarray_t *nd_array_c64_4d, flcl::flcl_ndarray_c64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    Kokkos::complex<double> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c64_4d = view_from_ndarray<Kokkos::complex<double>****>(*nd_array_c64_4d);
+    auto array_c64_4d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>****>(*nd_array_c64_4d);
     for (size_t ii = 0; ii < array_c64_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_4d.extent(2); kk++) {
@@ -996,12 +996,12 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
     
-    c_sum = Kokkos::complex<double>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c64_4d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_4d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_4d.extent(2); kk++) {
           for (size_t ll = 0; ll < array_c64_4d.extent(3); ll++) {
-            array_c64_4d(ii,jj,kk,ll) = Kokkos::complex<double>(1.0*(ii+jj+kk+ll),-1.0*(ii+jj+kk+ll));
+            array_c64_4d(ii,jj,kk,ll) = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(1.0*(ii+jj+kk+ll),-1.0*(ii+jj+kk+ll));
             c_sum = c_sum + array_c64_4d(ii,jj,kk,ll);
           }
         }
@@ -1011,11 +1011,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_l_5d( flcl_ndarray_t *nd_array_l_5d, size_t *f_sum ) {
+  flcl::flcl_ndarray_index_c_t c_test_ndarray_l_5d( flcl_ndarray_t *nd_array_l_5d, flcl::flcl_ndarray_index_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_l_5d = view_from_ndarray<bool*****>(*nd_array_l_5d);
+    flcl::flcl_ndarray_index_c_t c_sum = 0;
+    auto array_l_5d = view_from_ndarray<flcl::flcl_ndarray_l_c_t*****>(*nd_array_l_5d);
 
     for (size_t ii = 0; ii < array_l_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_l_5d.extent(1); jj++) {
@@ -1051,11 +1051,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i32_5d( flcl_ndarray_t *nd_array_i32_5d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i32_c_t c_test_ndarray_i32_5d( flcl_ndarray_t *nd_array_i32_5d, flcl::flcl_ndarray_i32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i32_5d = view_from_ndarray<int32_t*****>(*nd_array_i32_5d);
+    flcl::flcl_ndarray_i32_c_t c_sum = 0;
+    auto array_i32_5d = view_from_ndarray<flcl::flcl_ndarray_i32_c_t*****>(*nd_array_i32_5d);
 
     for (size_t ii = 0; ii < array_i32_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i32_5d.extent(1); jj++) {
@@ -1093,11 +1093,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i64_5d( flcl_ndarray_t *nd_array_i64_5d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i64_c_t c_test_ndarray_i64_5d( flcl_ndarray_t *nd_array_i64_5d, flcl::flcl_ndarray_i64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i64_5d = view_from_ndarray<int64_t*****>(*nd_array_i64_5d);
+    flcl::flcl_ndarray_i64_c_t c_sum = 0;
+    auto array_i64_5d = view_from_ndarray<flcl::flcl_ndarray_i64_c_t*****>(*nd_array_i64_5d);
 
     for (size_t ii = 0; ii < array_i64_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i64_5d.extent(1); jj++) {
@@ -1133,11 +1133,11 @@ extern "C" {
     return c_sum;
   }
 
-  float c_test_ndarray_r32_5d( flcl_ndarray_t *nd_array_r32_5d, float *f_sum ) {
+  flcl::flcl_ndarray_r32_c_t c_test_ndarray_r32_5d( flcl_ndarray_t *nd_array_r32_5d, flcl::flcl_ndarray_r32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    float c_sum = 0;
-    auto array_r32_5d = view_from_ndarray<float*****>(*nd_array_r32_5d);
+    flcl::flcl_ndarray_r32_c_t c_sum = 0;
+    auto array_r32_5d = view_from_ndarray<flcl::flcl_ndarray_r32_c_t*****>(*nd_array_r32_5d);
 
     for (size_t ii = 0; ii < array_r32_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r32_5d.extent(1); jj++) {
@@ -1178,11 +1178,11 @@ extern "C" {
     return c_sum;
   }
 
-  double c_test_ndarray_r64_5d( flcl_ndarray_t *nd_array_r64_5d, double *f_sum ) {
+  flcl::flcl_ndarray_r64_c_t c_test_ndarray_r64_5d( flcl_ndarray_t *nd_array_r64_5d, flcl::flcl_ndarray_r64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    double c_sum = 0;
-    auto array_r64_5d = view_from_ndarray<double*****>(*nd_array_r64_5d);
+    flcl::flcl_ndarray_r64_c_t c_sum = 0;
+    auto array_r64_5d = view_from_ndarray<flcl::flcl_ndarray_r64_c_t*****>(*nd_array_r64_5d);
 
     for (size_t ii = 0; ii < array_r64_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r64_5d.extent(1); jj++) {
@@ -1223,12 +1223,12 @@ extern "C" {
 
   }
 
-  std::complex<float> c_test_ndarray_c32_5d( flcl_ndarray_t *nd_array_c32_5d, std::complex<float> *f_sum ) {
+  flcl::flcl_ndarray_c32_c_t c_test_ndarray_c32_5d( flcl_ndarray_t *nd_array_c32_5d, flcl::flcl_ndarray_c32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
     
-    Kokkos::complex<float> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c32_5d = view_from_ndarray<Kokkos::complex<float>*****>(*nd_array_c32_5d);
+    auto array_c32_5d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>*****>(*nd_array_c32_5d);
     for (size_t ii = 0; ii < array_c32_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_5d.extent(2); kk++) {
@@ -1255,13 +1255,13 @@ extern "C" {
       exit(EXIT_FAILURE);
     }
 
-    c_sum = Kokkos::complex<float>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c32_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_5d.extent(2); kk++) {
           for (size_t ll = 0; ll < array_c32_5d.extent(3); ll++) {
             for (size_t mm = 0; mm < array_c32_5d.extent(4); mm++) {
-              array_c32_5d(ii,jj,kk,ll,mm) = Kokkos::complex<float>(1.0*(ii+jj+kk+ll+mm),-1.0*(ii+jj+kk+ll+mm));
+              array_c32_5d(ii,jj,kk,ll,mm) = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(1.0*(ii+jj+kk+ll+mm),-1.0*(ii+jj+kk+ll+mm));
               c_sum = c_sum + array_c32_5d(ii,jj,kk,ll,mm);
             }
           }
@@ -1272,12 +1272,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<double> c_test_ndarray_c64_5d( flcl_ndarray_t *nd_array_c64_5d, std::complex<double> *f_sum ) {
+  flcl::flcl_ndarray_c64_c_t c_test_ndarray_c64_5d( flcl_ndarray_t *nd_array_c64_5d, flcl::flcl_ndarray_c64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    Kokkos::complex<double> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c64_5d = view_from_ndarray<Kokkos::complex<double>*****>(*nd_array_c64_5d);
+    auto array_c64_5d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>*****>(*nd_array_c64_5d);
     for (size_t ii = 0; ii < array_c64_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_5d.extent(2); kk++) {
@@ -1304,13 +1304,13 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
     
-    c_sum = Kokkos::complex<double>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c64_5d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_5d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_5d.extent(2); kk++) {
           for (size_t ll = 0; ll < array_c64_5d.extent(3); ll++) {
             for (size_t mm = 0; mm < array_c64_5d.extent(4); mm++) {
-              array_c64_5d(ii,jj,kk,ll,mm) = Kokkos::complex<double>(1.0*(ii+jj+kk+ll+mm),-1.0*(ii+jj+kk+ll+mm));
+              array_c64_5d(ii,jj,kk,ll,mm) = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(1.0*(ii+jj+kk+ll+mm),-1.0*(ii+jj+kk+ll+mm));
               c_sum = c_sum + array_c64_5d(ii,jj,kk,ll,mm);
             }
           }
@@ -1321,11 +1321,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_l_6d( flcl_ndarray_t *nd_array_l_6d, size_t *f_sum ) {
+  flcl::flcl_ndarray_index_c_t c_test_ndarray_l_6d( flcl_ndarray_t *nd_array_l_6d, flcl::flcl_ndarray_index_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_l_6d = view_from_ndarray<bool******>(*nd_array_l_6d);
+    flcl::flcl_ndarray_index_c_t c_sum = 0;
+    auto array_l_6d = view_from_ndarray<flcl::flcl_ndarray_l_c_t******>(*nd_array_l_6d);
 
     for (size_t ii = 0; ii < array_l_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_l_6d.extent(1); jj++) {
@@ -1365,11 +1365,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i32_6d( flcl_ndarray_t *nd_array_i32_6d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i32_c_t c_test_ndarray_i32_6d( flcl_ndarray_t *nd_array_i32_6d, flcl::flcl_ndarray_i32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i32_6d = view_from_ndarray<int32_t******>(*nd_array_i32_6d);
+    flcl::flcl_ndarray_i32_c_t c_sum = 0;
+    auto array_i32_6d = view_from_ndarray<flcl::flcl_ndarray_i32_c_t******>(*nd_array_i32_6d);
 
     for (size_t ii = 0; ii < array_i32_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i32_6d.extent(1); jj++) {
@@ -1411,11 +1411,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i64_6d( flcl_ndarray_t *nd_array_i64_6d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i64_c_t c_test_ndarray_i64_6d( flcl_ndarray_t *nd_array_i64_6d, flcl::flcl_ndarray_i64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i64_6d = view_from_ndarray<int64_t******>(*nd_array_i64_6d);
+    flcl::flcl_ndarray_i64_c_t c_sum = 0;
+    auto array_i64_6d = view_from_ndarray<flcl::flcl_ndarray_i64_c_t******>(*nd_array_i64_6d);
 
     for (size_t ii = 0; ii < array_i64_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i64_6d.extent(1); jj++) {
@@ -1457,11 +1457,11 @@ extern "C" {
     return c_sum;
   }
 
-  float c_test_ndarray_r32_6d( flcl_ndarray_t *nd_array_r32_6d, float *f_sum ) {
+  flcl::flcl_ndarray_r32_c_t c_test_ndarray_r32_6d( flcl_ndarray_t *nd_array_r32_6d, flcl::flcl_ndarray_r32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    float c_sum = 0;
-    auto array_r32_6d = view_from_ndarray<float******>(*nd_array_r32_6d);
+    flcl::flcl_ndarray_r32_c_t c_sum = 0;
+    auto array_r32_6d = view_from_ndarray<flcl::flcl_ndarray_r32_c_t******>(*nd_array_r32_6d);
 
     for (size_t ii = 0; ii < array_r32_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r32_6d.extent(1); jj++) {
@@ -1506,11 +1506,11 @@ extern "C" {
     return c_sum;
   }
 
-  double c_test_ndarray_r64_6d( flcl_ndarray_t *nd_array_r64_6d, double *f_sum ) {
+  flcl::flcl_ndarray_r64_c_t c_test_ndarray_r64_6d( flcl_ndarray_t *nd_array_r64_6d, flcl::flcl_ndarray_r64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    double c_sum = 0;
-    auto array_r64_6d = view_from_ndarray<double******>(*nd_array_r64_6d);
+    flcl::flcl_ndarray_r64_c_t c_sum = 0;
+    auto array_r64_6d = view_from_ndarray<flcl::flcl_ndarray_r64_c_t******>(*nd_array_r64_6d);
 
     for (size_t ii = 0; ii < array_r64_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r64_6d.extent(1); jj++) {
@@ -1555,12 +1555,12 @@ extern "C" {
 
   }
 
-  std::complex<float> c_test_ndarray_c32_6d( flcl_ndarray_t *nd_array_c32_6d, std::complex<float> *f_sum ) {
+  flcl::flcl_ndarray_c32_c_t c_test_ndarray_c32_6d( flcl_ndarray_t *nd_array_c32_6d, flcl::flcl_ndarray_c32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
     
-    Kokkos::complex<float> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c32_6d = view_from_ndarray<Kokkos::complex<float>******>(*nd_array_c32_6d);
+    auto array_c32_6d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>******>(*nd_array_c32_6d);
     for (size_t ii = 0; ii < array_c32_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_6d.extent(2); kk++) {
@@ -1589,14 +1589,14 @@ extern "C" {
       exit(EXIT_FAILURE);
     }
 
-    c_sum = Kokkos::complex<float>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c32_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_6d.extent(2); kk++) {
           for (size_t ll = 0; ll < array_c32_6d.extent(3); ll++) {
             for (size_t mm = 0; mm < array_c32_6d.extent(4); mm++) {
               for (size_t nn = 0; nn < array_c32_6d.extent(5); nn++) {
-                array_c32_6d(ii,jj,kk,ll,mm,nn) = Kokkos::complex<float>(1.0*(ii+jj+kk+ll+mm+nn),-1.0*(ii+jj+kk+ll+mm+nn));
+                array_c32_6d(ii,jj,kk,ll,mm,nn) = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(1.0*(ii+jj+kk+ll+mm+nn),-1.0*(ii+jj+kk+ll+mm+nn));
                 c_sum = c_sum + array_c32_6d(ii,jj,kk,ll,mm,nn);
               }
             }
@@ -1608,12 +1608,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<double> c_test_ndarray_c64_6d( flcl_ndarray_t *nd_array_c64_6d, std::complex<double> *f_sum ) {
+  flcl::flcl_ndarray_c64_c_t c_test_ndarray_c64_6d( flcl_ndarray_t *nd_array_c64_6d, flcl::flcl_ndarray_c64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    Kokkos::complex<double> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c64_6d = view_from_ndarray<Kokkos::complex<double>******>(*nd_array_c64_6d);
+    auto array_c64_6d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>******>(*nd_array_c64_6d);
     for (size_t ii = 0; ii < array_c64_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_6d.extent(2); kk++) {
@@ -1642,14 +1642,14 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
     
-    c_sum = Kokkos::complex<double>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c64_6d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_6d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_6d.extent(2); kk++) {
           for (size_t ll = 0; ll < array_c64_6d.extent(3); ll++) {
             for (size_t mm = 0; mm < array_c64_6d.extent(4); mm++) {
               for (size_t nn = 0; nn < array_c64_6d.extent(5); nn++) {
-                array_c64_6d(ii,jj,kk,ll,mm,nn) = Kokkos::complex<double>(1.0*(ii+jj+kk+ll+mm+nn),-1.0*(ii+jj+kk+ll+mm+nn));
+                array_c64_6d(ii,jj,kk,ll,mm,nn) = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(1.0*(ii+jj+kk+ll+mm+nn),-1.0*(ii+jj+kk+ll+mm+nn));
                 c_sum = c_sum + array_c64_6d(ii,jj,kk,ll,mm,nn);
               }
             }
@@ -1661,11 +1661,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_l_7d( flcl_ndarray_t *nd_array_l_7d, size_t *f_sum ) {
+  flcl::flcl_ndarray_index_c_t c_test_ndarray_l_7d( flcl_ndarray_t *nd_array_l_7d, flcl::flcl_ndarray_index_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_l_7d = view_from_ndarray<bool*******>(*nd_array_l_7d);
+    flcl::flcl_ndarray_index_c_t c_sum = 0;
+    auto array_l_7d = view_from_ndarray<flcl::flcl_ndarray_l_c_t*******>(*nd_array_l_7d);
 
     for (size_t ii = 0; ii < array_l_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_l_7d.extent(1); jj++) {
@@ -1709,11 +1709,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i32_7d( flcl_ndarray_t *nd_array_i32_7d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i32_c_t c_test_ndarray_i32_7d( flcl_ndarray_t *nd_array_i32_7d, flcl::flcl_ndarray_i32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i32_7d = view_from_ndarray<int32_t*******>(*nd_array_i32_7d);
+    flcl::flcl_ndarray_i32_c_t c_sum = 0;
+    auto array_i32_7d = view_from_ndarray<flcl::flcl_ndarray_i32_c_t*******>(*nd_array_i32_7d);
 
     for (size_t ii = 0; ii < array_i32_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i32_7d.extent(1); jj++) {
@@ -1759,11 +1759,11 @@ extern "C" {
     return c_sum;
   }
 
-  size_t c_test_ndarray_i64_7d( flcl_ndarray_t *nd_array_i64_7d, size_t *f_sum ) {
+  flcl::flcl_ndarray_i64_c_t c_test_ndarray_i64_7d( flcl_ndarray_t *nd_array_i64_7d, flcl::flcl_ndarray_i64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    size_t c_sum = 0;
-    auto array_i64_7d = view_from_ndarray<int64_t*******>(*nd_array_i64_7d);
+    flcl::flcl_ndarray_i64_c_t c_sum = 0;
+    auto array_i64_7d = view_from_ndarray<flcl::flcl_ndarray_i64_c_t*******>(*nd_array_i64_7d);
 
     for (size_t ii = 0; ii < array_i64_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_i64_7d.extent(1); jj++) {
@@ -1809,11 +1809,11 @@ extern "C" {
     return c_sum;
   }
 
-  float c_test_ndarray_r32_7d( flcl_ndarray_t *nd_array_r32_7d, float *f_sum ) {
+  flcl::flcl_ndarray_r32_c_t c_test_ndarray_r32_7d( flcl_ndarray_t *nd_array_r32_7d, flcl::flcl_ndarray_r32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    float c_sum = 0;
-    auto array_r32_7d = view_from_ndarray<float*******>(*nd_array_r32_7d);
+    flcl::flcl_ndarray_r32_c_t c_sum = 0;
+    auto array_r32_7d = view_from_ndarray<flcl::flcl_ndarray_r32_c_t*******>(*nd_array_r32_7d);
 
     for (size_t ii = 0; ii < array_r32_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r32_7d.extent(1); jj++) {
@@ -1861,11 +1861,11 @@ extern "C" {
     return c_sum;
   }
 
-  double c_test_ndarray_r64_7d( flcl_ndarray_t *nd_array_r64_7d, double *f_sum ) {
+  flcl::flcl_ndarray_r64_c_t c_test_ndarray_r64_7d( flcl_ndarray_t *nd_array_r64_7d, flcl::flcl_ndarray_r64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    double c_sum = 0;
-    auto array_r64_7d = view_from_ndarray<double*******>(*nd_array_r64_7d);
+    flcl::flcl_ndarray_r64_c_t c_sum = 0;
+    auto array_r64_7d = view_from_ndarray<flcl::flcl_ndarray_r64_c_t*******>(*nd_array_r64_7d);
 
     for (size_t ii = 0; ii < array_r64_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_r64_7d.extent(1); jj++) {
@@ -1914,12 +1914,12 @@ extern "C" {
 
   }
 
-  std::complex<float> c_test_ndarray_c32_7d( flcl_ndarray_t *nd_array_c32_7d, std::complex<float> *f_sum ) {
+  flcl::flcl_ndarray_c32_c_t c_test_ndarray_c32_7d( flcl_ndarray_t *nd_array_c32_7d, flcl::flcl_ndarray_c32_c_t *f_sum ) {
     using flcl::view_from_ndarray;
     
-    Kokkos::complex<float> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c32_7d = view_from_ndarray<Kokkos::complex<float>*******>(*nd_array_c32_7d);
+    auto array_c32_7d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>*******>(*nd_array_c32_7d);
     for (size_t ii = 0; ii < array_c32_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_7d.extent(2); kk++) {
@@ -1950,7 +1950,7 @@ extern "C" {
       exit(EXIT_FAILURE);
     }
 
-    c_sum = Kokkos::complex<float>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c32_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c32_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c32_7d.extent(2); kk++) {
@@ -1958,7 +1958,7 @@ extern "C" {
             for (size_t mm = 0; mm < array_c32_7d.extent(4); mm++) {
               for (size_t nn = 0; nn < array_c32_7d.extent(5); nn++) {
                 for (size_t oo = 0; oo < array_c32_7d.extent(6); oo++) {
-                  array_c32_7d(ii,jj,kk,ll,mm,nn,oo) = Kokkos::complex<float>(1.0*(ii+jj+kk+ll+mm+nn+oo),-1.0*(ii+jj+kk+ll+mm+nn+oo));
+                  array_c32_7d(ii,jj,kk,ll,mm,nn,oo) = Kokkos::complex<flcl::flcl_ndarray_c32_scalar_c_t>(1.0*(ii+jj+kk+ll+mm+nn+oo),-1.0*(ii+jj+kk+ll+mm+nn+oo));
                   c_sum = c_sum + array_c32_7d(ii,jj,kk,ll,mm,nn,oo);
                 }
               }
@@ -1971,12 +1971,12 @@ extern "C" {
     return c_sum;
   }
 
-  std::complex<double> c_test_ndarray_c64_7d( flcl_ndarray_t *nd_array_c64_7d, std::complex<double> *f_sum ) {
+  flcl::flcl_ndarray_c64_c_t c_test_ndarray_c64_7d( flcl_ndarray_t *nd_array_c64_7d, flcl::flcl_ndarray_c64_c_t *f_sum ) {
     using flcl::view_from_ndarray;
 
-    Kokkos::complex<double> c_sum(0.0,0.0);
+    Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t> c_sum(0.0,0.0);
 
-    auto array_c64_7d = view_from_ndarray<Kokkos::complex<double>*******>(*nd_array_c64_7d);
+    auto array_c64_7d = view_from_ndarray<Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>*******>(*nd_array_c64_7d);
     for (size_t ii = 0; ii < array_c64_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_7d.extent(2); kk++) {
@@ -2007,7 +2007,7 @@ extern "C" {
       exit(EXIT_FAILURE);    
     }
     
-    c_sum = Kokkos::complex<double>(0.0,0.0);
+    c_sum = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(0.0,0.0);
     for (size_t ii = 0; ii < array_c64_7d.extent(0); ii++) {
       for (size_t jj = 0; jj < array_c64_7d.extent(1); jj++) {
         for (size_t kk = 0; kk < array_c64_7d.extent(2); kk++) {
@@ -2015,7 +2015,7 @@ extern "C" {
             for (size_t mm = 0; mm < array_c64_7d.extent(4); mm++) {
               for (size_t nn = 0; nn < array_c64_7d.extent(5); nn++) {
                 for (size_t oo = 0; oo < array_c64_7d.extent(6); oo++) {
-                  array_c64_7d(ii,jj,kk,ll,mm,nn,oo) = Kokkos::complex<double>(1.0*(ii+jj+kk+ll+mm+nn+oo),-1.0*(ii+jj+kk+ll+mm+nn+oo));
+                  array_c64_7d(ii,jj,kk,ll,mm,nn,oo) = Kokkos::complex<flcl::flcl_ndarray_c64_scalar_c_t>(1.0*(ii+jj+kk+ll+mm+nn+oo),-1.0*(ii+jj+kk+ll+mm+nn+oo));
                   c_sum = c_sum + array_c64_7d(ii,jj,kk,ll,mm,nn,oo);
                 }
               }

--- a/test/flcl-test-cxx.cpp
+++ b/test/flcl-test-cxx.cpp
@@ -3069,13 +3069,13 @@ extern "C" {
 
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_l_1d( flcl::dualview_l_1d_t **v_array_l_1d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_l_1d( flcl::dualview_l_1d_t **v_array_l_1d, flcl::flcl_dualview_index_c_t *f_sum, flcl::flcl_dualview_index_c_t *c_sum ) {
     using view_type = flcl::dualview_l_1d_t;
     *c_sum = 0;
     auto array_l_1d = **v_array_l_1d;
     array_l_1d.template modify<typename view_type::host_mirror_space>();
     array_l_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_1d_get", array_l_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_1d_get", array_l_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_index_c_t& temp_sum)
     {
       if (array_l_1d.d_view(idx)) temp_sum++;
     }, *c_sum );
@@ -3099,13 +3099,13 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_1d( flcl::dualview_i32_1d_t **v_array_i32_1d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_1d( flcl::dualview_i32_1d_t **v_array_i32_1d, flcl::flcl_dualview_i32_c_t *f_sum, flcl::flcl_dualview_i32_c_t *c_sum ) {
     using view_type = flcl::dualview_i32_1d_t;
     *c_sum = 0;
     auto array_i32_1d = **v_array_i32_1d;
     array_i32_1d.template modify<typename view_type::host_mirror_space>();
     array_i32_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_1d_get", array_i32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_1d_get", array_i32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       temp_sum += array_i32_1d.d_view(idx);
     }, *c_sum );
@@ -3120,7 +3120,7 @@ extern "C" {
     *c_sum = 0;
     array_i32_1d.template modify<typename view_type::host_mirror_space>();
     array_i32_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_1d_set", array_i32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_1d_set", array_i32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       array_i32_1d.d_view(idx) = idx;
       temp_sum += array_i32_1d.d_view(idx);
@@ -3131,13 +3131,13 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_1d( flcl::dualview_i64_1d_t **v_array_i64_1d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_1d( flcl::dualview_i64_1d_t **v_array_i64_1d, flcl::flcl_dualview_i64_c_t *f_sum, flcl::flcl_dualview_i64_c_t *c_sum ) {
     using view_type = flcl::dualview_i64_1d_t;
     *c_sum = 0;
     auto array_i64_1d = **v_array_i64_1d;
     array_i64_1d.template modify<typename view_type::host_mirror_space>();
     array_i64_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_1d_get", array_i64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_1d_get", array_i64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       temp_sum += array_i64_1d.d_view(idx);
     }, *c_sum );
@@ -3152,7 +3152,7 @@ extern "C" {
     *c_sum = 0;
     array_i64_1d.template modify<typename view_type::host_mirror_space>();
     array_i64_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_1d_set", array_i64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_1d_set", array_i64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       array_i64_1d.d_view(idx) = idx;
       temp_sum += array_i64_1d.d_view(idx);
@@ -3163,13 +3163,13 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_1d( flcl::dualview_r32_1d_t **v_array_r32_1d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_1d( flcl::dualview_r32_1d_t **v_array_r32_1d, flcl::flcl_dualview_r32_c_t *f_sum, flcl::flcl_dualview_r32_c_t *c_sum ) {
     using view_type = flcl::dualview_r32_1d_t;
     *c_sum = 0;
     auto array_r32_1d = **v_array_r32_1d;
     array_r32_1d.template modify<typename view_type::host_mirror_space>();
     array_r32_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_1d_get", array_r32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_1d_get", array_r32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       temp_sum += array_r32_1d.d_view(idx);
     }, *c_sum );
@@ -3184,7 +3184,7 @@ extern "C" {
     *c_sum = 0;
     array_r32_1d.template modify<typename view_type::host_mirror_space>();
     array_r32_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_1d_set", array_r32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_1d_set", array_r32_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       array_r32_1d.d_view(idx) = idx;
       temp_sum += array_r32_1d.d_view(idx);
@@ -3195,13 +3195,13 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_1d( flcl::dualview_r64_1d_t **v_array_r64_1d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_1d( flcl::dualview_r64_1d_t **v_array_r64_1d, flcl::flcl_dualview_r64_c_t *f_sum, flcl::flcl_dualview_r64_c_t *c_sum ) {
     using view_type = flcl::dualview_r64_1d_t;
     *c_sum = 0;
     auto array_r64_1d = **v_array_r64_1d;
     array_r64_1d.template modify<typename view_type::host_mirror_space>();
     array_r64_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_1d_get", array_r64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_1d_get", array_r64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       temp_sum += array_r64_1d.d_view(idx);
     }, *c_sum );
@@ -3216,7 +3216,7 @@ extern "C" {
     *c_sum = 0;
     array_r64_1d.template modify<typename view_type::host_mirror_space>();
     array_r64_1d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_1d_set", array_r64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_1d_set", array_r64_1d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       array_r64_1d.d_view(idx) = idx;
       temp_sum += array_r64_1d.d_view(idx);
@@ -3227,13 +3227,13 @@ extern "C" {
     return FLCL_TEST_PASS;
   }
 
-flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **v_array_l_2d, size_t *f_sum, size_t *c_sum ) {
+flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **v_array_l_2d, flcl::flcl_dualview_index_c_t *f_sum, flcl::flcl_dualview_index_c_t *c_sum ) {
     using view_type = flcl::dualview_l_2d_t;
     *c_sum = 0;
     auto array_l_2d = **v_array_l_2d;
     array_l_2d.template modify<typename view_type::host_mirror_space>();
     array_l_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_2d_get", array_l_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_l_2d_get", array_l_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_index_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_l_2d.extent(1); jj++) { 
         if (array_l_2d.d_view(idx,jj)) temp_sum++;
@@ -3262,13 +3262,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_2d( flcl::dualview_i32_2d_t **v_array_i32_2d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i32_2d( flcl::dualview_i32_2d_t **v_array_i32_2d, flcl::flcl_dualview_i32_c_t *f_sum, flcl::flcl_dualview_i32_c_t *c_sum ) {
     using view_type = flcl::dualview_i32_2d_t;
     *c_sum = 0;
     auto array_i32_2d = **v_array_i32_2d;
     array_i32_2d.template modify<typename view_type::host_mirror_space>();
     array_i32_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_2d_get", array_i32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_2d_get", array_i32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_2d.extent(1); jj++) {
         temp_sum += array_i32_2d.d_view(idx,jj);
@@ -3285,7 +3285,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     *c_sum = 0;
     array_i32_2d.template modify<typename view_type::host_mirror_space>();
     array_i32_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_2d_set", array_i32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i32_2d_set", array_i32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i32_2d.extent(1); jj++) {
         array_i32_2d.d_view(idx,jj) = idx+jj;
@@ -3298,13 +3298,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_2d( flcl::dualview_i64_2d_t **v_array_i64_2d, size_t *f_sum, size_t *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_i64_2d( flcl::dualview_i64_2d_t **v_array_i64_2d, flcl::flcl_dualview_i64_c_t *f_sum, flcl::flcl_dualview_i64_c_t *c_sum ) {
     using view_type = flcl::dualview_i64_2d_t;
     *c_sum = 0;
     auto array_i64_2d = **v_array_i64_2d;
     array_i64_2d.template modify<typename view_type::host_mirror_space>();
     array_i64_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_2d_get", array_i64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_2d_get", array_i64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_2d.extent(1); jj++) {
         temp_sum += array_i64_2d.d_view(idx,jj);
@@ -3321,7 +3321,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     *c_sum = 0;
     array_i64_2d.template modify<typename view_type::host_mirror_space>();
     array_i64_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_2d_set", array_i64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, size_t& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_i64_2d_set", array_i64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_i64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_i64_2d.extent(1); jj++) {
         array_i64_2d.d_view(idx,jj) = idx+jj;
@@ -3334,13 +3334,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_2d( flcl::dualview_r32_2d_t **v_array_r32_2d, float *f_sum, float *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r32_2d( flcl::dualview_r32_2d_t **v_array_r32_2d, flcl::flcl_dualview_r32_c_t *f_sum, flcl::flcl_dualview_r32_c_t *c_sum ) {
     using view_type = flcl::dualview_r32_2d_t;
     *c_sum = 0;
     auto array_r32_2d = **v_array_r32_2d;
     array_r32_2d.template modify<typename view_type::host_mirror_space>();
     array_r32_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_2d_get", array_r32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_2d_get", array_r32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_2d.extent(1); jj++) {
         temp_sum += array_r32_2d.d_view(idx,jj);
@@ -3357,7 +3357,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     *c_sum = 0;
     array_r32_2d.template modify<typename view_type::host_mirror_space>();
     array_r32_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_2d_set", array_r32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, float& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r32_2d_set", array_r32_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r32_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r32_2d.extent(1); jj++) {
         array_r32_2d.d_view(idx,jj) = idx+jj;
@@ -3370,13 +3370,13 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     return FLCL_TEST_PASS;
   }
 
-  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_2d( flcl::dualview_r64_2d_t **v_array_r64_2d, double *f_sum, double *c_sum ) {
+  flcl_test_error_t c_test_kokkos_allocate_dualview_r64_2d( flcl::dualview_r64_2d_t **v_array_r64_2d, flcl::flcl_dualview_r64_c_t *f_sum, flcl::flcl_dualview_r64_c_t *c_sum ) {
     using view_type = flcl::dualview_r64_2d_t;
     *c_sum = 0;
     auto array_r64_2d = **v_array_r64_2d;
     array_r64_2d.template modify<typename view_type::host_mirror_space>();
     array_r64_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_2d_get", array_r64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_2d_get", array_r64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_2d.extent(1); jj++) {
         temp_sum += array_r64_2d.d_view(idx,jj);
@@ -3393,7 +3393,7 @@ flcl_test_error_t c_test_kokkos_allocate_dualview_l_2d( flcl::dualview_l_2d_t **
     *c_sum = 0;
     array_r64_2d.template modify<typename view_type::host_mirror_space>();
     array_r64_2d.template sync<typename view_type::execution_space>();
-    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_2d_set", array_r64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, double& temp_sum)
+    Kokkos::parallel_reduce( "c_test_kokkos_allocate_dualview_r64_2d_set", array_r64_2d.extent(0), KOKKOS_LAMBDA( const size_t&idx, flcl::flcl_dualview_r64_c_t& temp_sum)
     {
       for (size_t jj = 0; jj < array_r64_2d.extent(1); jj++) {
         array_r64_2d.d_view(idx,jj) = idx+jj;

--- a/test/flcl-test-cxx.h
+++ b/test/flcl-test-cxx.h
@@ -40,6 +40,7 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include "flcl-types-cxx.hpp"
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,13 +53,13 @@ typedef enum _flcl_test_error_t {
 } flcl_test_error_t;
 
 
-size_t e0_length = 8;
-size_t e1_length = 7;
-size_t e2_length = 6;
-size_t e3_length = 5;
-size_t e4_length = 4;
-size_t e5_length = 3;
-size_t e6_length = 2;
+flcl::flcl_ndarray_index_c_t e0_length = 8;
+flcl::flcl_ndarray_index_c_t e1_length = 7;
+flcl::flcl_ndarray_index_c_t e2_length = 6;
+flcl::flcl_ndarray_index_c_t e3_length = 5;
+flcl::flcl_ndarray_index_c_t e4_length = 4;
+flcl::flcl_ndarray_index_c_t e5_length = 3;
+flcl::flcl_ndarray_index_c_t e6_length = 2;
 
 float weak_precision_single = 1.0e-6;
 double weak_precision_double = 1.0e-13;

--- a/test/flcl-test-f.F90
+++ b/test/flcl-test-f.F90
@@ -81,541 +81,541 @@ module flcl_test_f_mod
   public
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_index_f_t) &
         & function f_test_ndarray_l_1d( nd_array_l_1d, f_sum ) &
         & bind(c, name='c_test_ndarray_l_1d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_l_1d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_index_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_l_1d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i32_f_t) &
         & function f_test_ndarray_i32_1d( nd_array_i32_1d, f_sum ) &
         & bind(c, name='c_test_ndarray_i32_1d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i32_1d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i32_1d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i64_f_t) &
         & function f_test_ndarray_i64_1d( nd_array_i64_1d, f_sum ) &
         & bind(c, name='c_test_ndarray_i64_1d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i64_1d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i64_1d
     end interface
 
     interface
-      real(c_float) &
+      real(flcl_ndarray_r32_f_t) &
         & function f_test_ndarray_r32_1d( nd_array_r32_1d, f_sum ) &
         & bind(c, name='c_test_ndarray_r32_1d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r32_1d
-        real(c_float), intent(inout) :: f_sum
+        real(flcl_ndarray_r32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r32_1d
     end interface
 
     interface
-      real(c_double) &
+      real(flcl_ndarray_r64_f_t) &
         & function f_test_ndarray_r64_1d( nd_array_r64_1d, f_sum ) &
         & bind(c, name='c_test_ndarray_r64_1d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r64_1d
-        real(c_double), intent(inout) :: f_sum
+        real(flcl_ndarray_r64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r64_1d
     end interface
 
     interface
-      complex(c_float_complex) &
+      complex(flcl_ndarray_c32_f_t) &
         & function f_test_ndarray_c32_1d( nd_array_c32_1d, f_sum ) &
         & bind(c, name='c_test_ndarray_c32_1d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c32_1d
-        complex(c_float_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c32_1d
     end interface
 
     interface
-      complex(c_double_complex) &
+      complex(flcl_ndarray_c64_f_t) &
         & function f_test_ndarray_c64_1d( nd_array_c64_1d, f_sum ) &
         & bind(c, name='c_test_ndarray_c64_1d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c64_1d
-        complex(c_double_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c64_1d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_index_f_t) &
         & function f_test_ndarray_l_2d( nd_array_l_2d, f_sum ) &
         & bind(c, name='c_test_ndarray_l_2d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_l_2d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_index_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_l_2d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i32_f_t) &
         & function f_test_ndarray_i32_2d( nd_array_i32_2d, f_sum ) &
         & bind(c, name='c_test_ndarray_i32_2d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i32_2d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i32_2d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i64_f_t) &
         & function f_test_ndarray_i64_2d( nd_array_i64_2d, f_sum ) &
         & bind(c, name='c_test_ndarray_i64_2d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i64_2d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i64_2d
     end interface
 
     interface
-      real(c_float) &
+      real(flcl_ndarray_r32_f_t) &
         & function f_test_ndarray_r32_2d( nd_array_r32_2d, f_sum ) &
         & bind(c, name='c_test_ndarray_r32_2d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r32_2d
-        real(c_float), intent(inout) :: f_sum
+        real(flcl_ndarray_r32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r32_2d
     end interface
 
     interface
-      real(c_double) &
+      real(flcl_ndarray_r64_f_t) &
         & function f_test_ndarray_r64_2d( nd_array_r64_2d, f_sum ) &
         & bind(c, name='c_test_ndarray_r64_2d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r64_2d
-        real(c_double), intent(inout) :: f_sum
+        real(flcl_ndarray_r64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r64_2d
     end interface
 
     interface
-      complex(c_float_complex) &
+      complex(flcl_ndarray_c32_f_t) &
         & function f_test_ndarray_c32_2d( nd_array_c32_2d, f_sum ) &
         & bind(c, name='c_test_ndarray_c32_2d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c32_2d
-        complex(c_float_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c32_2d
     end interface
 
     interface
-      complex(c_double_complex) &
+      complex(flcl_ndarray_c64_f_t) &
         & function f_test_ndarray_c64_2d( nd_array_c64_2d, f_sum ) &
         & bind(c, name='c_test_ndarray_c64_2d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c64_2d
-        complex(c_double_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c64_2d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_index_f_t) &
         & function f_test_ndarray_l_3d( nd_array_l_3d, f_sum ) &
         & bind(c, name='c_test_ndarray_l_3d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_l_3d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_index_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_l_3d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i32_f_t) &
         & function f_test_ndarray_i32_3d( nd_array_i32_3d, f_sum ) &
         & bind(c, name='c_test_ndarray_i32_3d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i32_3d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i32_3d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i64_f_t) &
         & function f_test_ndarray_i64_3d( nd_array_i64_3d, f_sum ) &
         & bind(c, name='c_test_ndarray_i64_3d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i64_3d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i64_3d
     end interface
 
     interface
-      real(c_float) &
+      real(flcl_ndarray_r32_f_t) &
         & function f_test_ndarray_r32_3d( nd_array_r32_3d, f_sum ) &
         & bind(c, name='c_test_ndarray_r32_3d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r32_3d
-        real(c_float), intent(inout) :: f_sum
+        real(flcl_ndarray_r32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r32_3d
     end interface
 
     interface
-      real(c_double) &
+      real(flcl_ndarray_r64_f_t) &
         & function f_test_ndarray_r64_3d( nd_array_r64_3d, f_sum ) &
         & bind(c, name='c_test_ndarray_r64_3d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r64_3d
-        real(c_double), intent(inout) :: f_sum
+        real(flcl_ndarray_r64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r64_3d
     end interface
 
     interface
-      complex(c_float_complex) &
+      complex(flcl_ndarray_c32_f_t) &
         & function f_test_ndarray_c32_3d( nd_array_c32_3d, f_sum ) &
         & bind(c, name='c_test_ndarray_c32_3d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c32_3d
-        complex(c_float_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c32_3d
     end interface
 
     interface
-      complex(c_double_complex) &
+      complex(flcl_ndarray_c64_f_t) &
         & function f_test_ndarray_c64_3d( nd_array_c64_3d, f_sum ) &
         & bind(c, name='c_test_ndarray_c64_3d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c64_3d
-        complex(c_double_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c64_3d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_index_f_t) &
         & function f_test_ndarray_l_4d( nd_array_l_4d, f_sum ) &
         & bind(c, name='c_test_ndarray_l_4d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_l_4d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_index_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_l_4d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i32_f_t) &
         & function f_test_ndarray_i32_4d( nd_array_i32_4d, f_sum ) &
         & bind(c, name='c_test_ndarray_i32_4d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i32_4d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i32_4d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i64_f_t) &
         & function f_test_ndarray_i64_4d( nd_array_i64_4d, f_sum ) &
         & bind(c, name='c_test_ndarray_i64_4d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i64_4d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i64_4d
     end interface
 
     interface
-      real(c_float) &
+      real(flcl_ndarray_r32_f_t) &
         & function f_test_ndarray_r32_4d( nd_array_r32_4d, f_sum ) &
         & bind(c, name='c_test_ndarray_r32_4d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r32_4d
-        real(c_float), intent(inout) :: f_sum
+        real(flcl_ndarray_r32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r32_4d
     end interface
 
     interface
-      real(c_double) &
+      real(flcl_ndarray_r64_f_t) &
         & function f_test_ndarray_r64_4d( nd_array_r64_4d, f_sum ) &
         & bind(c, name='c_test_ndarray_r64_4d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r64_4d
-        real(c_double), intent(inout) :: f_sum
+        real(flcl_ndarray_r64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r64_4d
     end interface
 
     interface
-      complex(c_float_complex) &
+      complex(flcl_ndarray_c32_f_t) &
         & function f_test_ndarray_c32_4d( nd_array_c32_4d, f_sum ) &
         & bind(c, name='c_test_ndarray_c32_4d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c32_4d
-        complex(c_float_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c32_4d
     end interface
 
     interface
-      complex(c_double_complex) &
+      complex(flcl_ndarray_c64_f_t) &
         & function f_test_ndarray_c64_4d( nd_array_c64_4d, f_sum ) &
         & bind(c, name='c_test_ndarray_c64_4d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c64_4d
-        complex(c_double_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c64_4d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_index_f_t) &
         & function f_test_ndarray_l_5d( nd_array_l_5d, f_sum ) &
         & bind(c, name='c_test_ndarray_l_5d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_l_5d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_index_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_l_5d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i32_f_t) &
         & function f_test_ndarray_i32_5d( nd_array_i32_5d, f_sum ) &
         & bind(c, name='c_test_ndarray_i32_5d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i32_5d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i32_5d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i64_f_t) &
         & function f_test_ndarray_i64_5d( nd_array_i64_5d, f_sum ) &
         & bind(c, name='c_test_ndarray_i64_5d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i64_5d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i64_5d
     end interface
 
     interface
-      real(c_float) &
+      real(flcl_ndarray_r32_f_t) &
         & function f_test_ndarray_r32_5d( nd_array_r32_5d, f_sum ) &
         & bind(c, name='c_test_ndarray_r32_5d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r32_5d
-        real(c_float), intent(inout) :: f_sum
+        real(flcl_ndarray_r32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r32_5d
     end interface
 
     interface
-      real(c_double) &
+      real(flcl_ndarray_r64_f_t) &
         & function f_test_ndarray_r64_5d( nd_array_r64_5d, f_sum ) &
         & bind(c, name='c_test_ndarray_r64_5d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r64_5d
-        real(c_double), intent(inout) :: f_sum
+        real(flcl_ndarray_r64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r64_5d
     end interface
 
     interface
-      complex(c_float_complex) &
+      complex(flcl_ndarray_c32_f_t) &
         & function f_test_ndarray_c32_5d( nd_array_c32_5d, f_sum ) &
         & bind(c, name='c_test_ndarray_c32_5d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c32_5d
-        complex(c_float_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c32_5d
     end interface
 
     interface
-      complex(c_double_complex) &
+      complex(flcl_ndarray_c64_f_t) &
         & function f_test_ndarray_c64_5d( nd_array_c64_5d, f_sum ) &
         & bind(c, name='c_test_ndarray_c64_5d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c64_5d
-        complex(c_double_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c64_5d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_index_f_t) &
         & function f_test_ndarray_l_6d( nd_array_l_6d, f_sum ) &
         & bind(c, name='c_test_ndarray_l_6d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_l_6d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_index_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_l_6d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i32_f_t) &
         & function f_test_ndarray_i32_6d( nd_array_i32_6d, f_sum ) &
         & bind(c, name='c_test_ndarray_i32_6d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i32_6d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i32_6d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i64_f_t) &
         & function f_test_ndarray_i64_6d( nd_array_i64_6d, f_sum ) &
         & bind(c, name='c_test_ndarray_i64_6d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i64_6d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i64_6d
     end interface
 
     interface
-      real(c_float) &
+      real(flcl_ndarray_r32_f_t) &
         & function f_test_ndarray_r32_6d( nd_array_r32_6d, f_sum ) &
         & bind(c, name='c_test_ndarray_r32_6d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r32_6d
-        real(c_float), intent(inout) :: f_sum
+        real(flcl_ndarray_r32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r32_6d
     end interface
 
     interface
-      real(c_double) &
+      real(flcl_ndarray_r64_f_t) &
         & function f_test_ndarray_r64_6d( nd_array_r64_6d, f_sum ) &
         & bind(c, name='c_test_ndarray_r64_6d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r64_6d
-        real(c_double), intent(inout) :: f_sum
+        real(flcl_ndarray_r64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r64_6d
     end interface
 
     interface
-      complex(c_float_complex) &
+      complex(flcl_ndarray_c32_f_t) &
         & function f_test_ndarray_c32_6d( nd_array_c32_6d, f_sum ) &
         & bind(c, name='c_test_ndarray_c32_6d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c32_6d
-        complex(c_float_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c32_6d
     end interface
 
     interface
-      complex(c_double_complex) &
+      complex(flcl_ndarray_c64_f_t) &
         & function f_test_ndarray_c64_6d( nd_array_c64_6d, f_sum ) &
         & bind(c, name='c_test_ndarray_c64_6d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c64_6d
-        complex(c_double_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c64_6d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_index_f_t) &
         & function f_test_ndarray_l_7d( nd_array_l_7d, f_sum ) &
         & bind(c, name='c_test_ndarray_l_7d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_l_7d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_index_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_l_7d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i32_f_t) &
         & function f_test_ndarray_i32_7d( nd_array_i32_7d, f_sum ) &
         & bind(c, name='c_test_ndarray_i32_7d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i32_7d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i32_7d
     end interface
 
     interface
-      integer(c_size_t) &
+      integer(flcl_ndarray_i64_f_t) &
         & function f_test_ndarray_i64_7d( nd_array_i64_7d, f_sum ) &
         & bind(c, name='c_test_ndarray_i64_7d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_i64_7d
-        integer(c_size_t), intent(inout) :: f_sum
+        integer(flcl_ndarray_i64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_i64_7d
     end interface
 
     interface
-      real(c_float) &
+      real(flcl_ndarray_r32_f_t) &
         & function f_test_ndarray_r32_7d( nd_array_r32_7d, f_sum ) &
         & bind(c, name='c_test_ndarray_r32_7d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r32_7d
-        real(c_float), intent(inout) :: f_sum
+        real(flcl_ndarray_r32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r32_7d
     end interface
 
     interface
-      real(c_double) &
+      real(flcl_ndarray_r64_f_t) &
         & function f_test_ndarray_r64_7d( nd_array_r64_7d, f_sum ) &
         & bind(c, name='c_test_ndarray_r64_7d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_r64_7d
-        real(c_double), intent(inout) :: f_sum
+        real(flcl_ndarray_r64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_r64_7d
     end interface
 
     interface
-      complex(c_float_complex) &
+      complex(flcl_ndarray_c32_f_t) &
         & function f_test_ndarray_c32_7d( nd_array_c32_7d, f_sum ) &
         & bind(c, name='c_test_ndarray_c32_7d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c32_7d
-        complex(c_float_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c32_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c32_7d
     end interface
 
     interface
-      complex(c_double_complex) &
+      complex(flcl_ndarray_c64_f_t) &
         & function f_test_ndarray_c64_7d( nd_array_c64_7d, f_sum ) &
         & bind(c, name='c_test_ndarray_c64_7d')
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(nd_array_t), intent(in) :: nd_array_c64_7d
-        complex(c_double_complex), intent(inout) :: f_sum
+        complex(flcl_ndarray_c64_f_t), intent(inout) :: f_sum
       end function f_test_ndarray_c64_7d
     end interface
 
@@ -626,8 +626,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_1d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_index_f_t), intent(inout) :: f_sum
+        integer(flcl_view_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_l_1d
     end interface
 
@@ -638,8 +638,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_1d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i32_1d
     end interface
 
@@ -650,8 +650,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_1d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i64_1d
     end interface
 
@@ -662,8 +662,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_1d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_view_r32_f_t), intent(inout) :: f_sum
+        real(flcl_view_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r32_1d
     end interface
 
@@ -674,8 +674,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_1d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_view_r64_f_t), intent(inout) :: f_sum
+        real(flcl_view_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r64_1d
     end interface
 
@@ -686,8 +686,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_2d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_index_f_t), intent(inout) :: f_sum
+        integer(flcl_view_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_l_2d
     end interface
 
@@ -698,8 +698,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_2d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i32_2d
     end interface
 
@@ -710,8 +710,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_2d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i64_2d
     end interface
 
@@ -722,8 +722,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_2d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_view_r32_f_t), intent(inout) :: f_sum
+        real(flcl_view_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r32_2d
     end interface
 
@@ -734,8 +734,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_2d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_view_r64_f_t), intent(inout) :: f_sum
+        real(flcl_view_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r64_2d
     end interface
 
@@ -746,8 +746,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_3d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_index_f_t), intent(inout) :: f_sum
+        integer(flcl_view_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_l_3d
     end interface
 
@@ -758,8 +758,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_3d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i32_3d
     end interface
 
@@ -770,8 +770,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_3d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i64_3d
     end interface
 
@@ -782,8 +782,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_3d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_view_r32_f_t), intent(inout) :: f_sum
+        real(flcl_view_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r32_3d
     end interface
 
@@ -794,8 +794,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_3d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_view_r64_f_t), intent(inout) :: f_sum
+        real(flcl_view_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r64_3d
     end interface
 
@@ -806,8 +806,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_4d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_index_f_t), intent(inout) :: f_sum
+        integer(flcl_view_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_l_4d
     end interface
 
@@ -818,8 +818,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_4d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i32_4d
     end interface
 
@@ -830,8 +830,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_4d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i64_4d
     end interface
 
@@ -842,8 +842,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_4d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_view_r32_f_t), intent(inout) :: f_sum
+        real(flcl_view_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r32_4d
     end interface
 
@@ -854,8 +854,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_4d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_view_r64_f_t), intent(inout) :: f_sum
+        real(flcl_view_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r64_4d
     end interface
 
@@ -866,8 +866,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_5d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_index_f_t), intent(inout) :: f_sum
+        integer(flcl_view_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_l_5d
     end interface
 
@@ -878,8 +878,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_5d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i32_5d
     end interface
 
@@ -890,8 +890,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_5d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i64_5d
     end interface
 
@@ -902,8 +902,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_5d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_view_r32_f_t), intent(inout) :: f_sum
+        real(flcl_view_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r32_5d
     end interface
 
@@ -914,8 +914,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_5d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_view_r64_f_t), intent(inout) :: f_sum
+        real(flcl_view_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r64_5d
     end interface
 
@@ -926,8 +926,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_6d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_index_f_t), intent(inout) :: f_sum
+        integer(flcl_view_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_l_6d
     end interface
 
@@ -938,8 +938,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_6d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i32_6d
     end interface
 
@@ -950,8 +950,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_6d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i64_6d
     end interface
 
@@ -962,8 +962,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_6d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_view_r32_f_t), intent(inout) :: f_sum
+        real(flcl_view_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r32_6d
     end interface
 
@@ -974,8 +974,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_6d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_view_r64_f_t), intent(inout) :: f_sum
+        real(flcl_view_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r64_6d
     end interface
 
@@ -986,8 +986,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_7d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_index_f_t), intent(inout) :: f_sum
+        integer(flcl_view_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_l_7d
     end interface
 
@@ -998,8 +998,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_7d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i32_7d
     end interface
 
@@ -1010,8 +1010,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_7d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_view_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_i64_7d
     end interface
 
@@ -1022,8 +1022,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_7d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_view_r32_f_t), intent(inout) :: f_sum
+        real(flcl_view_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r32_7d
     end interface
 
@@ -1034,8 +1034,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_7d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_view_r64_f_t), intent(inout) :: f_sum
+        real(flcl_view_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_view_r64_7d
     end interface
 
@@ -1046,8 +1046,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_1d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_l_1d
     end interface
 
@@ -1058,8 +1058,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_1d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i32_1d
     end interface
 
@@ -1070,8 +1070,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_1d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i64_1d
     end interface
 
@@ -1082,8 +1082,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_1d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r32_1d
     end interface
 
@@ -1094,8 +1094,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_1d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r64_1d
     end interface
 
@@ -1106,8 +1106,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_2d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_l_2d
     end interface
 
@@ -1118,8 +1118,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_2d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i32_2d
     end interface
 
@@ -1130,8 +1130,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_2d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i64_2d
     end interface
 
@@ -1142,8 +1142,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_2d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r32_2d
     end interface
 
@@ -1154,8 +1154,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_2d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r64_2d
     end interface
 
@@ -1166,8 +1166,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_3d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_l_3d
     end interface
 
@@ -1178,8 +1178,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_3d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i32_3d
     end interface
 
@@ -1190,8 +1190,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_3d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i64_3d
     end interface
 
@@ -1202,8 +1202,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_3d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r32_3d
     end interface
 
@@ -1214,8 +1214,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_3d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r64_3d
     end interface
 
@@ -1226,8 +1226,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_4d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_l_4d
     end interface
 
@@ -1238,8 +1238,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_4d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i32_4d
     end interface
 
@@ -1250,8 +1250,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_4d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i64_4d
     end interface
 
@@ -1262,8 +1262,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_4d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r32_4d
     end interface
 
@@ -1274,8 +1274,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_4d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r64_4d
     end interface
 
@@ -1286,8 +1286,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_5d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_l_5d
     end interface
 
@@ -1298,8 +1298,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_5d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i32_5d
     end interface
 
@@ -1310,8 +1310,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_5d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i64_5d
     end interface
 
@@ -1322,8 +1322,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_5d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r32_5d
     end interface
 
@@ -1334,8 +1334,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_5d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r64_5d
     end interface
 
@@ -1346,8 +1346,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_6d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_l_6d
     end interface
 
@@ -1358,8 +1358,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_6d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i32_6d
     end interface
 
@@ -1370,8 +1370,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_6d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i64_6d
     end interface
 
@@ -1382,8 +1382,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_6d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r32_6d
     end interface
 
@@ -1394,8 +1394,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_6d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r64_6d
     end interface
 
@@ -1406,8 +1406,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_l_7d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_index_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_l_7d
     end interface
 
@@ -1418,8 +1418,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i32_7d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i32_7d
     end interface
 
@@ -1430,8 +1430,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_i64_7d
-        integer(c_size_t), intent(inout) :: f_sum
-        integer(c_size_t), intent(inout) :: c_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: f_sum
+        integer(flcl_dualview_i64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_i64_7d
     end interface
 
@@ -1442,8 +1442,8 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r32_7d
-        real(c_float), intent(inout) :: f_sum
-        real(c_float), intent(inout) :: c_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r32_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r32_7d
     end interface
 
@@ -1454,14 +1454,14 @@ module flcl_test_f_mod
         use, intrinsic :: iso_c_binding
         use :: flcl_mod
         type(c_ptr), intent(in) :: v_array_r64_7d
-        real(c_double), intent(inout) :: f_sum
-        real(c_double), intent(inout) :: c_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: f_sum
+        real(flcl_dualview_r64_f_t), intent(inout) :: c_sum
       end function f_test_kokkos_allocate_dualview_r64_7d
     end interface
 
     contains
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_l_1d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1470,8 +1470,8 @@ module flcl_test_f_mod
 
         logical(flcl_ndarray_l_f_t), dimension(:), allocatable :: array_l_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = e0_length
+        integer(flcl_ndarray_index_f_t) :: f_sum = 0
+        integer(flcl_ndarray_index_f_t) :: c_sum = e0_length
         integer(c_size_t) :: test_state_zero = flcl_test_fail
         integer(c_size_t) :: test_state_values = flcl_test_fail
         type(nd_array_t) :: zero_ndarray
@@ -1518,7 +1518,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_l_1d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_i32_1d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1527,8 +1527,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i32_f_t), dimension(:), allocatable :: array_i32_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = e0_length
+        integer(flcl_ndarray_i32_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: c_sum = e0_length
 
         allocate( array_i32_1d(e0_length) )
         do ii = 1, e0_length
@@ -1553,7 +1553,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i32_1d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_i64_1d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1562,8 +1562,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i64_f_t), dimension(:), allocatable :: array_i64_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = e0_length
+        integer(flcl_ndarray_i64_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: c_sum = e0_length
 
         allocate( array_i64_1d(e0_length) )
         do ii = 1, e0_length
@@ -1588,7 +1588,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i64_1d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_r32_1d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1623,7 +1623,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r32_1d
   
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_r64_1d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1658,7 +1658,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r64_1d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c32_1d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1694,7 +1694,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c32_1d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c64_1d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1730,7 +1730,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c64_1d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_l_2d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1739,8 +1739,8 @@ module flcl_test_f_mod
 
         logical(flcl_ndarray_l_f_t), dimension(:,:), allocatable :: array_l_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_index_f_t) :: f_sum = 0
+        integer(flcl_ndarray_index_f_t) :: c_sum = 0
 
         allocate( array_l_2d(e0_length, e1_length) )
         do ii = 1, e0_length
@@ -1773,7 +1773,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_l_2d
   
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_i32_2d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1782,8 +1782,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i32_f_t), dimension(:,:), allocatable :: array_i32_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: c_sum = 0
 
         allocate( array_i32_2d(e0_length, e1_length) )
         do ii = 1, e0_length
@@ -1812,7 +1812,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i32_2d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_i64_2d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1821,8 +1821,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i64_f_t), dimension(:,:), allocatable :: array_i64_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: c_sum = 0
 
         allocate( array_i64_2d(e0_length, e1_length) )
         do ii = 1, e0_length
@@ -1851,7 +1851,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i64_2d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_r32_2d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1890,7 +1890,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r32_2d
   
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_r64_2d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1929,7 +1929,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r64_2d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c32_2d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -1969,7 +1969,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c32_2d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c64_2d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2009,7 +2009,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c64_2d
 
-      integer(c_size_t) & 
+      integer & 
         & function test_ndarray_l_3d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2018,8 +2018,8 @@ module flcl_test_f_mod
 
         logical(flcl_ndarray_l_f_t), dimension(:,:,:), allocatable :: array_l_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_index_f_t) :: f_sum = 0
+        integer(flcl_ndarray_index_f_t) :: c_sum = 0
 
         allocate( array_l_3d(e0_length, e1_length, e2_length) )
         do ii = 1, e0_length
@@ -2056,7 +2056,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_l_3d
   
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_i32_3d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2065,8 +2065,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i32_f_t), dimension(:,:,:), allocatable :: array_i32_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: c_sum = 0
 
         allocate( array_i32_3d(e0_length, e1_length, e2_length) )
         do ii = 1, e0_length
@@ -2099,7 +2099,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i32_3d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_i64_3d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2108,8 +2108,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i64_f_t), dimension(:,:,:), allocatable :: array_i64_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: c_sum = 0
 
         allocate( array_i64_3d(e0_length, e1_length, e2_length) )
         do ii = 1, e0_length
@@ -2142,7 +2142,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i64_3d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_r32_3d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2185,7 +2185,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r32_3d
   
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_r64_3d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2228,7 +2228,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r64_3d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c32_3d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2272,7 +2272,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c32_3d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c64_3d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2316,7 +2316,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c64_3d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_l_4d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2325,8 +2325,8 @@ module flcl_test_f_mod
 
         logical(flcl_ndarray_l_f_t), dimension(:,:,:,:), allocatable :: array_l_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_index_f_t) :: f_sum = 0
+        integer(flcl_ndarray_index_f_t) :: c_sum = 0
 
         allocate( array_l_4d(e0_length, e1_length, e2_length, e3_length) )
         do ii = 1, e0_length
@@ -2367,7 +2367,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_l_4d
   
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i32_4d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2376,8 +2376,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:), allocatable :: array_i32_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: c_sum = 0
 
         allocate( array_i32_4d(e0_length, e1_length, e2_length, e3_length) )
         do ii = 1, e0_length
@@ -2414,7 +2414,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i32_4d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i64_4d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2423,8 +2423,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:), allocatable :: array_i64_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: c_sum = 0
 
         allocate( array_i64_4d(e0_length, e1_length, e2_length, e3_length) )
         do ii = 1, e0_length
@@ -2461,7 +2461,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i64_4d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r32_4d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2508,7 +2508,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r32_4d
   
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r64_4d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2555,7 +2555,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r64_4d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c32_4d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2603,7 +2603,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c32_4d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c64_4d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2651,7 +2651,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c64_4d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_l_5d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2660,8 +2660,8 @@ module flcl_test_f_mod
 
         logical(flcl_ndarray_l_f_t), dimension(:,:,:,:,:), allocatable :: array_l_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_index_f_t) :: f_sum = 0
+        integer(flcl_ndarray_index_f_t) :: c_sum = 0
 
         allocate( array_l_5d(e0_length, e1_length, e2_length, e3_length, e4_length) )
         do ii = 1, e0_length
@@ -2706,7 +2706,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_l_5d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i32_5d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2715,8 +2715,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:,:), allocatable :: array_i32_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: c_sum = 0
 
         allocate( array_i32_5d(e0_length, e1_length, e2_length, e3_length, e4_length) )
         do ii = 1, e0_length
@@ -2757,7 +2757,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i32_5d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i64_5d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2766,8 +2766,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:,:), allocatable :: array_i64_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: c_sum = 0
 
         allocate( array_i64_5d(e0_length, e1_length, e2_length, e3_length, e4_length) )
         do ii = 1, e0_length
@@ -2808,7 +2808,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i64_5d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r32_5d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2861,7 +2861,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r32_5d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r64_5d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2912,7 +2912,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r64_5d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c32_5d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -2964,7 +2964,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c32_5d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c64_5d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3016,7 +3016,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c64_5d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_l_6d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3025,8 +3025,8 @@ module flcl_test_f_mod
 
         logical(flcl_ndarray_l_f_t), dimension(:,:,:,:,:,:), allocatable :: array_l_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_index_f_t) :: f_sum = 0
+        integer(flcl_ndarray_index_f_t) :: c_sum = 0
 
         allocate( array_l_6d(e0_length, e1_length, e2_length, e3_length, e4_length, e5_length) )
         do ii = 1, e0_length
@@ -3075,7 +3075,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_l_6d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i32_6d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3084,8 +3084,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:,:,:), allocatable :: array_i32_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: c_sum = 0
 
         allocate( array_i32_6d(e0_length, e1_length, e2_length, e3_length, e4_length, e5_length) )
         do ii = 1, e0_length
@@ -3130,7 +3130,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i32_6d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i64_6d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3139,8 +3139,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:,:,:), allocatable :: array_i64_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: c_sum = 0
 
         allocate( array_i64_6d(e0_length, e1_length, e2_length, e3_length, e4_length, e5_length) )
         do ii = 1, e0_length
@@ -3185,7 +3185,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i64_6d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r32_6d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3243,7 +3243,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r32_6d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r64_6d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3298,7 +3298,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r64_6d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c32_6d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3354,7 +3354,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c32_6d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c64_6d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3410,7 +3410,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c64_6d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_l_7d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3419,8 +3419,8 @@ module flcl_test_f_mod
 
         logical(flcl_ndarray_l_f_t), dimension(:,:,:,:,:,:,:), allocatable :: array_l_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_index_f_t) :: f_sum = 0
+        integer(flcl_ndarray_index_f_t) :: c_sum = 0
 
         allocate( array_l_7d(e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length) )
         do ii = 1, e0_length
@@ -3473,7 +3473,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_l_7d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i32_7d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3482,8 +3482,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:,:,:,:), allocatable :: array_i32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i32_f_t) :: c_sum = 0
 
         allocate( array_i32_7d(e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length) )
         do ii = 1, e0_length
@@ -3532,7 +3532,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i32_7d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_i64_7d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3541,8 +3541,8 @@ module flcl_test_f_mod
 
         integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:,:,:,:), allocatable :: array_i64_7d
         integer :: ii, jj, kk, ll, mm, nn,oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: f_sum = 0
+        integer(flcl_ndarray_i64_f_t) :: c_sum = 0
 
         allocate( array_i64_7d(e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length) )
         do ii = 1, e0_length
@@ -3591,7 +3591,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_i64_7d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r32_7d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3650,7 +3650,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r32_7d
 
-      integer(c_size_t) &
+      integer &
         & function  test_ndarray_r64_7d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3709,7 +3709,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_r64_7d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c32_7d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3769,7 +3769,7 @@ module flcl_test_f_mod
         end if
       end function test_ndarray_c32_7d
 
-      integer(c_size_t) &
+      integer &
         & function test_ndarray_c64_7d() &
         & result(ierr)
         use, intrinsic :: iso_c_binding
@@ -3839,8 +3839,8 @@ module flcl_test_f_mod
         logical(flcl_view_l_f_t), pointer, dimension(:)  :: array_l_1d
         type(view_l_1d_t) :: v_array_l_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_index_f_t) :: f_sum = 0
+        integer(flcl_view_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_l_1d, v_array_l_1d, 'array_l_1d', e0_length )
         do ii = 1, e0_length
@@ -3883,8 +3883,8 @@ module flcl_test_f_mod
         integer(flcl_view_i32_f_t), pointer, dimension(:)  :: array_i32_1d
         type(view_i32_1d_t) :: v_array_i32_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i32_f_t) :: f_sum = 0
+        integer(flcl_view_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i32_1d, v_array_i32_1d, 'array_i32_1d', e0_length )
         do ii = 1, e0_length
@@ -3922,8 +3922,8 @@ module flcl_test_f_mod
         integer(flcl_view_i64_f_t), pointer, dimension(:)  :: array_i64_1d
         type(view_i64_1d_t) :: v_array_i64_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i64_f_t) :: f_sum = 0
+        integer(flcl_view_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i64_1d, v_array_i64_1d, 'array_i64_1d', e0_length )
         do ii = 1, e0_length
@@ -3958,11 +3958,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:)  :: array_r32_1d
+        real(flcl_view_r32_f_t), pointer, dimension(:)  :: array_r32_1d
         type(view_r32_1d_t) :: v_array_r32_1d
         integer :: ii
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_view_r32_f_t) :: f_sum = 0
+        real(flcl_view_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r32_1d, v_array_r32_1d, 'array_r32_1d', e0_length )
         do ii = 1, e0_length
@@ -3997,11 +3997,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:)  :: array_r64_1d
+        real(flcl_view_r64_f_t), pointer, dimension(:)  :: array_r64_1d
         type(view_r64_1d_t) :: v_array_r64_1d
         integer :: ii
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_view_r64_f_t) :: f_sum = 0
+        real(flcl_view_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r64_1d, v_array_r64_1d, 'array_r64_1d', e0_length )
         do ii = 1, e0_length
@@ -4039,8 +4039,8 @@ module flcl_test_f_mod
         logical(flcl_view_l_f_t), pointer, dimension(:,:)  :: array_l_2d
         type(view_l_2d_t) :: v_array_l_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_index_f_t) :: f_sum = 0
+        integer(flcl_view_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_l_2d, v_array_l_2d, 'array_l_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -4086,8 +4086,8 @@ module flcl_test_f_mod
         integer(flcl_view_i32_f_t), pointer, dimension(:,:)  :: array_i32_2d
         type(view_i32_2d_t) :: v_array_i32_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i32_f_t) :: f_sum = 0
+        integer(flcl_view_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i32_2d, v_array_i32_2d, 'array_i32_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -4129,8 +4129,8 @@ module flcl_test_f_mod
         integer(flcl_view_i64_f_t), pointer, dimension(:,:)  :: array_i64_2d
         type(view_i64_2d_t) :: v_array_i64_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i64_f_t) :: f_sum = 0
+        integer(flcl_view_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i64_2d, v_array_i64_2d, 'array_i64_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -4169,11 +4169,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:)  :: array_r32_2d
+        real(flcl_view_r32_f_t), pointer, dimension(:,:)  :: array_r32_2d
         type(view_r32_2d_t) :: v_array_r32_2d
         integer :: ii, jj
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_view_r32_f_t) :: f_sum = 0
+        real(flcl_view_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r32_2d, v_array_r32_2d, 'array_r32_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -4212,11 +4212,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:)  :: array_r64_2d
+        real(flcl_view_r64_f_t), pointer, dimension(:,:)  :: array_r64_2d
         type(view_r64_2d_t) :: v_array_r64_2d
         integer :: ii, jj
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_view_r64_f_t) :: f_sum = 0
+        real(flcl_view_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r64_2d, v_array_r64_2d, 'array_r64_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -4258,8 +4258,8 @@ module flcl_test_f_mod
         logical(flcl_view_l_f_t), pointer, dimension(:,:,:)  :: array_l_3d
         type(view_l_3d_t) :: v_array_l_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_index_f_t) :: f_sum = 0
+        integer(flcl_view_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_l_3d, v_array_l_3d, 'array_l_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -4309,8 +4309,8 @@ module flcl_test_f_mod
         integer(flcl_view_i32_f_t), pointer, dimension(:,:,:)  :: array_i32_3d
         type(view_i32_3d_t) :: v_array_i32_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i32_f_t) :: f_sum = 0
+        integer(flcl_view_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i32_3d, v_array_i32_3d, 'array_i32_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -4356,8 +4356,8 @@ module flcl_test_f_mod
         integer(flcl_view_i64_f_t), pointer, dimension(:,:,:)  :: array_i64_3d
         type(view_i64_3d_t) :: v_array_i64_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i64_f_t) :: f_sum = 0
+        integer(flcl_view_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i64_3d, v_array_i64_3d, 'array_i64_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -4400,11 +4400,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:)  :: array_r32_3d
+        real(flcl_view_r32_f_t), pointer, dimension(:,:,:)  :: array_r32_3d
         type(view_r32_3d_t) :: v_array_r32_3d
         integer :: ii, jj, kk
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_view_r32_f_t) :: f_sum = 0
+        real(flcl_view_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r32_3d, v_array_r32_3d, 'array_r32_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -4447,11 +4447,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:)  :: array_r64_3d
+        real(flcl_view_r64_f_t), pointer, dimension(:,:,:)  :: array_r64_3d
         type(view_r64_3d_t) :: v_array_r64_3d
         integer :: ii, jj, kk
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_view_r64_f_t) :: f_sum = 0
+        real(flcl_view_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r64_3d, v_array_r64_3d, 'array_r64_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -4497,8 +4497,8 @@ module flcl_test_f_mod
         logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:)  :: array_l_4d
         type(view_l_4d_t) :: v_array_l_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_index_f_t) :: f_sum = 0
+        integer(flcl_view_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_l_4d, v_array_l_4d, 'array_l_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -4552,8 +4552,8 @@ module flcl_test_f_mod
         integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:)  :: array_i32_4d
         type(view_i32_4d_t) :: v_array_i32_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i32_f_t) :: f_sum = 0
+        integer(flcl_view_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i32_4d, v_array_i32_4d, 'array_i32_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -4603,8 +4603,8 @@ module flcl_test_f_mod
         integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:)  :: array_i64_4d
         type(view_i64_4d_t) :: v_array_i64_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i64_f_t) :: f_sum = 0
+        integer(flcl_view_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i64_4d, v_array_i64_4d, 'array_i64_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -4651,11 +4651,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:)  :: array_r32_4d
+        real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:)  :: array_r32_4d
         type(view_r32_4d_t) :: v_array_r32_4d
         integer :: ii, jj, kk, ll
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_view_r32_f_t) :: f_sum = 0
+        real(flcl_view_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r32_4d, v_array_r32_4d, 'array_r32_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -4702,11 +4702,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:)  :: array_r64_4d
+        real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:)  :: array_r64_4d
         type(view_r64_4d_t) :: v_array_r64_4d
         integer :: ii, jj, kk, ll
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_view_r64_f_t) :: f_sum = 0
+        real(flcl_view_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r64_4d, v_array_r64_4d, 'array_r64_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -4756,8 +4756,8 @@ module flcl_test_f_mod
         logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:)  :: array_l_5d
         type(view_l_5d_t) :: v_array_l_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_index_f_t) :: f_sum = 0
+        integer(flcl_view_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_l_5d, v_array_l_5d, 'array_l_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -4816,8 +4816,8 @@ module flcl_test_f_mod
         integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:)  :: array_i32_5d
         type(view_i32_5d_t) :: v_array_i32_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i32_f_t) :: f_sum = 0
+        integer(flcl_view_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i32_5d, v_array_i32_5d, 'array_i32_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -4872,8 +4872,8 @@ module flcl_test_f_mod
         integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:)  :: array_i64_5d
         type(view_i64_5d_t) :: v_array_i64_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i64_f_t) :: f_sum = 0
+        integer(flcl_view_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i64_5d, v_array_i64_5d, 'array_i64_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -4925,11 +4925,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:,:)  :: array_r32_5d
+        real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:)  :: array_r32_5d
         type(view_r32_5d_t) :: v_array_r32_5d
         integer :: ii, jj, kk, ll, mm
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_view_r32_f_t) :: f_sum = 0
+        real(flcl_view_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r32_5d, v_array_r32_5d, 'array_r32_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -4981,11 +4981,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:,:)  :: array_r64_5d
+        real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:)  :: array_r64_5d
         type(view_r64_5d_t) :: v_array_r64_5d
         integer :: ii, jj, kk, ll, mm
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_view_r64_f_t) :: f_sum = 0
+        real(flcl_view_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r64_5d, v_array_r64_5d, 'array_r64_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -5040,8 +5040,8 @@ module flcl_test_f_mod
         logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_l_6d
         type(view_l_6d_t) :: v_array_l_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_index_f_t) :: f_sum = 0
+        integer(flcl_view_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_l_6d, v_array_l_6d, 'array_l_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -5104,8 +5104,8 @@ module flcl_test_f_mod
         integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i32_6d
         type(view_i32_6d_t) :: v_array_i32_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i32_f_t) :: f_sum = 0
+        integer(flcl_view_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i32_6d, v_array_i32_6d, 'array_i32_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -5164,8 +5164,8 @@ module flcl_test_f_mod
         integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i64_6d
         type(view_i64_6d_t) :: v_array_i64_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i64_f_t) :: f_sum = 0
+        integer(flcl_view_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i64_6d, v_array_i64_6d, 'array_i64_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -5221,11 +5221,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:,:,:)  :: array_r32_6d
+        real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_r32_6d
         type(view_r32_6d_t) :: v_array_r32_6d
         integer :: ii, jj, kk, ll, mm, nn
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_view_r32_f_t) :: f_sum = 0
+        real(flcl_view_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r32_6d, v_array_r32_6d, 'array_r32_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -5281,11 +5281,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:,:,:)  :: array_r64_6d
+        real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_r64_6d
         type(view_r64_6d_t) :: v_array_r64_6d
         integer :: ii, jj, kk, ll, mm, nn
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_view_r64_f_t) :: f_sum = 0
+        real(flcl_view_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r64_6d, v_array_r64_6d, 'array_r64_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -5344,8 +5344,8 @@ module flcl_test_f_mod
         logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_l_7d
         type(view_l_7d_t) :: v_array_l_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_index_f_t) :: f_sum = 0
+        integer(flcl_view_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_l_7d, v_array_l_7d, 'array_l_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -5412,8 +5412,8 @@ module flcl_test_f_mod
         integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i32_7d
         type(view_i32_7d_t) :: v_array_i32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i32_f_t) :: f_sum = 0
+        integer(flcl_view_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i32_7d, v_array_i32_7d, 'array_i32_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -5476,8 +5476,8 @@ module flcl_test_f_mod
         integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i64_7d
         type(view_i64_7d_t) :: v_array_i64_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_view_i64_f_t) :: f_sum = 0
+        integer(flcl_view_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_i64_7d, v_array_i64_7d, 'array_i64_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -5537,11 +5537,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:,:,:,:)  :: array_r32_7d
+        real(flcl_view_r32_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_r32_7d
         type(view_r32_7d_t) :: v_array_r32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_view_r32_f_t) :: f_sum = 0
+        real(flcl_view_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r32_7d, v_array_r32_7d, 'array_r32_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -5601,11 +5601,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:,:,:,:)  :: array_r64_7d
+        real(flcl_view_r64_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_r64_7d
         type(view_r64_7d_t) :: v_array_r64_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_view_r64_f_t) :: f_sum = 0
+        real(flcl_view_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_view( array_r64_7d, v_array_r64_7d, 'array_r64_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -5668,8 +5668,8 @@ module flcl_test_f_mod
         logical(flcl_dualview_l_f_t), pointer, dimension(:)  :: array_l_1d
         type(dualview_l_1d_t) :: v_array_l_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_index_f_t) :: f_sum = 0
+        integer(flcl_dualview_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_l_1d, v_array_l_1d, 'array_l_1d', e0_length )
         do ii = 1, e0_length
@@ -5712,8 +5712,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i32_f_t), pointer, dimension(:)  :: array_i32_1d
         type(dualview_i32_1d_t) :: v_array_i32_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i32_f_t) :: f_sum = 0
+        integer(flcl_dualview_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i32_1d, v_array_i32_1d, 'array_i32_1d', e0_length )
         do ii = 1, e0_length
@@ -5751,8 +5751,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i64_f_t), pointer, dimension(:)  :: array_i64_1d
         type(dualview_i64_1d_t) :: v_array_i64_1d
         integer :: ii
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i64_f_t) :: f_sum = 0
+        integer(flcl_dualview_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i64_1d, v_array_i64_1d, 'array_i64_1d', e0_length )
         do ii = 1, e0_length
@@ -5787,11 +5787,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:)  :: array_r32_1d
+        real(flcl_dualview_r32_f_t), pointer, dimension(:)  :: array_r32_1d
         type(dualview_r32_1d_t) :: v_array_r32_1d
         integer :: ii
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_dualview_r32_f_t) :: f_sum = 0
+        real(flcl_dualview_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r32_1d, v_array_r32_1d, 'array_r32_1d', e0_length )
         do ii = 1, e0_length
@@ -5826,11 +5826,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:)  :: array_r64_1d
+        real(flcl_dualview_r64_f_t), pointer, dimension(:)  :: array_r64_1d
         type(dualview_r64_1d_t) :: v_array_r64_1d
         integer :: ii
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_dualview_r64_f_t) :: f_sum = 0
+        real(flcl_dualview_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r64_1d, v_array_r64_1d, 'array_r64_1d', e0_length )
         do ii = 1, e0_length
@@ -5868,8 +5868,8 @@ module flcl_test_f_mod
         logical(flcl_dualview_l_f_t), pointer, dimension(:,:)  :: array_l_2d
         type(dualview_l_2d_t) :: v_array_l_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_index_f_t) :: f_sum = 0
+        integer(flcl_dualview_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_l_2d, v_array_l_2d, 'array_l_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -5915,8 +5915,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i32_f_t), pointer, dimension(:,:)  :: array_i32_2d
         type(dualview_i32_2d_t) :: v_array_i32_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i32_f_t) :: f_sum = 0
+        integer(flcl_dualview_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i32_2d, v_array_i32_2d, 'array_i32_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -5958,8 +5958,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i64_f_t), pointer, dimension(:,:)  :: array_i64_2d
         type(dualview_i64_2d_t) :: v_array_i64_2d
         integer :: ii, jj
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i64_f_t) :: f_sum = 0
+        integer(flcl_dualview_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i64_2d, v_array_i64_2d, 'array_i64_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -5998,11 +5998,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:)  :: array_r32_2d
+        real(flcl_dualview_r32_f_t), pointer, dimension(:,:)  :: array_r32_2d
         type(dualview_r32_2d_t) :: v_array_r32_2d
         integer :: ii, jj
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_dualview_r32_f_t) :: f_sum = 0
+        real(flcl_dualview_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r32_2d, v_array_r32_2d, 'array_r32_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -6041,11 +6041,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:)  :: array_r64_2d
+        real(flcl_dualview_r64_f_t), pointer, dimension(:,:)  :: array_r64_2d
         type(dualview_r64_2d_t) :: v_array_r64_2d
         integer :: ii, jj
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_dualview_r64_f_t) :: f_sum = 0
+        real(flcl_dualview_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r64_2d, v_array_r64_2d, 'array_r64_2d', e0_length, e1_length )
         do ii = 1, e0_length
@@ -6087,8 +6087,8 @@ module flcl_test_f_mod
         logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:)  :: array_l_3d
         type(dualview_l_3d_t) :: v_array_l_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_index_f_t) :: f_sum = 0
+        integer(flcl_dualview_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_l_3d, v_array_l_3d, 'array_l_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -6138,8 +6138,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:)  :: array_i32_3d
         type(dualview_i32_3d_t) :: v_array_i32_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i32_f_t) :: f_sum = 0
+        integer(flcl_dualview_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i32_3d, v_array_i32_3d, 'array_i32_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -6185,8 +6185,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:)  :: array_i64_3d
         type(dualview_i64_3d_t) :: v_array_i64_3d
         integer :: ii, jj, kk
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i64_f_t) :: f_sum = 0
+        integer(flcl_dualview_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i64_3d, v_array_i64_3d, 'array_i64_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -6229,11 +6229,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:)  :: array_r32_3d
+        real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:)  :: array_r32_3d
         type(dualview_r32_3d_t) :: v_array_r32_3d
         integer :: ii, jj, kk
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_dualview_r32_f_t) :: f_sum = 0
+        real(flcl_dualview_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r32_3d, v_array_r32_3d, 'array_r32_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -6276,11 +6276,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:)  :: array_r64_3d
+        real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:)  :: array_r64_3d
         type(dualview_r64_3d_t) :: v_array_r64_3d
         integer :: ii, jj, kk
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_dualview_r64_f_t) :: f_sum = 0
+        real(flcl_dualview_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r64_3d, v_array_r64_3d, 'array_r64_3d', e0_length, e1_length, e2_length )
         do ii = 1, e0_length
@@ -6326,8 +6326,8 @@ module flcl_test_f_mod
         logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:)  :: array_l_4d
         type(dualview_l_4d_t) :: v_array_l_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_index_f_t) :: f_sum = 0
+        integer(flcl_dualview_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_l_4d, v_array_l_4d, 'array_l_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -6381,8 +6381,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:)  :: array_i32_4d
         type(dualview_i32_4d_t) :: v_array_i32_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i32_f_t) :: f_sum = 0
+        integer(flcl_dualview_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i32_4d, v_array_i32_4d, 'array_i32_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -6432,8 +6432,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:)  :: array_i64_4d
         type(dualview_i64_4d_t) :: v_array_i64_4d
         integer :: ii, jj, kk, ll
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i64_f_t) :: f_sum = 0
+        integer(flcl_dualview_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i64_4d, v_array_i64_4d, 'array_i64_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -6480,11 +6480,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:)  :: array_r32_4d
+        real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:)  :: array_r32_4d
         type(dualview_r32_4d_t) :: v_array_r32_4d
         integer :: ii, jj, kk, ll
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_dualview_r32_f_t) :: f_sum = 0
+        real(flcl_dualview_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r32_4d, v_array_r32_4d, 'array_r32_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -6531,11 +6531,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:)  :: array_r64_4d
+        real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:)  :: array_r64_4d
         type(dualview_r64_4d_t) :: v_array_r64_4d
         integer :: ii, jj, kk, ll
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_dualview_r64_f_t) :: f_sum = 0
+        real(flcl_dualview_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r64_4d, v_array_r64_4d, 'array_r64_4d', e0_length, e1_length, e2_length, e3_length )
         do ii = 1, e0_length
@@ -6585,8 +6585,8 @@ module flcl_test_f_mod
         logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:)  :: array_l_5d
         type(dualview_l_5d_t) :: v_array_l_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_index_f_t) :: f_sum = 0
+        integer(flcl_dualview_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_l_5d, v_array_l_5d, 'array_l_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -6645,8 +6645,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:)  :: array_i32_5d
         type(dualview_i32_5d_t) :: v_array_i32_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i32_f_t) :: f_sum = 0
+        integer(flcl_dualview_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i32_5d, v_array_i32_5d, 'array_i32_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -6701,8 +6701,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:)  :: array_i64_5d
         type(dualview_i64_5d_t) :: v_array_i64_5d
         integer :: ii, jj, kk, ll, mm
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i64_f_t) :: f_sum = 0
+        integer(flcl_dualview_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i64_5d, v_array_i64_5d, 'array_i64_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -6754,11 +6754,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:,:)  :: array_r32_5d
+        real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:)  :: array_r32_5d
         type(dualview_r32_5d_t) :: v_array_r32_5d
         integer :: ii, jj, kk, ll, mm
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_dualview_r32_f_t) :: f_sum = 0
+        real(flcl_dualview_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r32_5d, v_array_r32_5d, 'array_r32_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -6810,11 +6810,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:,:)  :: array_r64_5d
+        real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:)  :: array_r64_5d
         type(dualview_r64_5d_t) :: v_array_r64_5d
         integer :: ii, jj, kk, ll, mm
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_dualview_r64_f_t) :: f_sum = 0
+        real(flcl_dualview_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r64_5d, v_array_r64_5d, 'array_r64_5d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length )
@@ -6869,8 +6869,8 @@ module flcl_test_f_mod
         logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_l_6d
         type(dualview_l_6d_t) :: v_array_l_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_index_f_t) :: f_sum = 0
+        integer(flcl_dualview_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_l_6d, v_array_l_6d, 'array_l_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -6933,8 +6933,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i32_6d
         type(dualview_i32_6d_t) :: v_array_i32_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i32_f_t) :: f_sum = 0
+        integer(flcl_dualview_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i32_6d, v_array_i32_6d, 'array_i32_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -6993,8 +6993,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i64_6d
         type(dualview_i64_6d_t) :: v_array_i64_6d
         integer :: ii, jj, kk, ll, mm, nn
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i64_f_t) :: f_sum = 0
+        integer(flcl_dualview_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i64_6d, v_array_i64_6d, 'array_i64_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -7050,11 +7050,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:,:,:)  :: array_r32_6d
+        real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_r32_6d
         type(dualview_r32_6d_t) :: v_array_r32_6d
         integer :: ii, jj, kk, ll, mm, nn
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_dualview_r32_f_t) :: f_sum = 0
+        real(flcl_dualview_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r32_6d, v_array_r32_6d, 'array_r32_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -7110,11 +7110,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:,:,:)  :: array_r64_6d
+        real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_r64_6d
         type(dualview_r64_6d_t) :: v_array_r64_6d
         integer :: ii, jj, kk, ll, mm, nn
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_dualview_r64_f_t) :: f_sum = 0
+        real(flcl_dualview_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r64_6d, v_array_r64_6d, 'array_r64_6d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length )
@@ -7173,8 +7173,8 @@ module flcl_test_f_mod
         logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_l_7d
         type(dualview_l_7d_t) :: v_array_l_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_index_f_t) :: f_sum = 0
+        integer(flcl_dualview_index_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_l_7d, v_array_l_7d, 'array_l_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -7241,8 +7241,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i32_7d
         type(dualview_i32_7d_t) :: v_array_i32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i32_f_t) :: f_sum = 0
+        integer(flcl_dualview_i32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i32_7d, v_array_i32_7d, 'array_i32_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -7305,8 +7305,8 @@ module flcl_test_f_mod
         integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i64_7d
         type(dualview_i64_7d_t) :: v_array_i64_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        integer(c_size_t) :: f_sum = 0
-        integer(c_size_t) :: c_sum = 0
+        integer(flcl_dualview_i64_f_t) :: f_sum = 0
+        integer(flcl_dualview_i64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_i64_7d, v_array_i64_7d, 'array_i64_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -7366,11 +7366,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_float), pointer, dimension(:,:,:,:,:,:,:)  :: array_r32_7d
+        real(flcl_dualview_r32_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_r32_7d
         type(dualview_r32_7d_t) :: v_array_r32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        real(c_float) :: f_sum = 0
-        real(c_float) :: c_sum = 0
+        real(flcl_dualview_r32_f_t) :: f_sum = 0
+        real(flcl_dualview_r32_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r32_7d, v_array_r32_7d, 'array_r32_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )
@@ -7430,11 +7430,11 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        real(c_double), pointer, dimension(:,:,:,:,:,:,:)  :: array_r64_7d
+        real(flcl_dualview_r64_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_r64_7d
         type(dualview_r64_7d_t) :: v_array_r64_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
-        real(c_double) :: f_sum = 0
-        real(c_double) :: c_sum = 0
+        real(flcl_dualview_r64_f_t) :: f_sum = 0
+        real(flcl_dualview_r64_f_t) :: c_sum = 0
 
         call kokkos_allocate_dualview( array_r64_7d, v_array_r64_7d, 'array_r64_7d', &
           & e0_length, e1_length, e2_length, e3_length, e4_length, e5_length, e6_length )

--- a/test/flcl-test-f.F90
+++ b/test/flcl-test-f.F90
@@ -71,8 +71,12 @@ module flcl_test_f_mod
     enumerator :: flcl_test_fail = 1
   end enum
 
-  real(c_float) :: precision_single = 1.0e-7
-  real(c_double) :: precision_double = 1.0e-14
+  real(flcl_ndarray_r32_f_t)  :: ndarray_precision_single = 1.0e-7
+  real(flcl_ndarray_r64_f_t)  :: ndarray_precision_double = 1.0e-14
+  real(flcl_view_r32_f_t)     :: view_precision_single = 1.0e-7
+  real(flcl_view_r64_f_t)     :: view_precision_double = 1.0e-14
+  real(flcl_dualview_r32_f_t) :: dualview_precision_single = 1.0e-7
+  real(flcl_dualview_r64_f_t) :: dualview_precision_double = 1.0e-14
 
   public
 
@@ -1464,7 +1468,7 @@ module flcl_test_f_mod
         use :: flcl_ndarray_mod
         implicit none
 
-        logical(c_bool), dimension(:), allocatable :: array_l_1d
+        logical(flcl_ndarray_l_f_t), dimension(:), allocatable :: array_l_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = e0_length
@@ -1521,7 +1525,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), dimension(:), allocatable :: array_i32_1d
+        integer(flcl_ndarray_i32_f_t), dimension(:), allocatable :: array_i32_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = e0_length
@@ -1556,7 +1560,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), dimension(:), allocatable :: array_i64_1d
+        integer(flcl_ndarray_i64_f_t), dimension(:), allocatable :: array_i64_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = e0_length
@@ -1606,7 +1610,7 @@ module flcl_test_f_mod
         do ii = 1, e0_length
           f_sum = f_sum + array_r32_1d(ii)
         end do
-        if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+        if ( abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum) ) then
           write(*,*)'PASSED ndarray_r32_1d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -1641,7 +1645,7 @@ module flcl_test_f_mod
         do ii = 1, e0_length
           f_sum = f_sum + array_r64_1d(ii)
         end do
-        if ( abs(f_sum - c_sum ) < precision_double * c_sum ) then
+        if ( abs(f_sum - c_sum ) < ndarray_precision_single * c_sum ) then
           write(*,*)'PASSED ndarray_r64_1d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -1676,8 +1680,8 @@ module flcl_test_f_mod
         do ii = 1, e0_length
           f_sum = f_sum + array_c32_1d(ii)
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_single * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_single * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c32_1d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -1712,8 +1716,8 @@ module flcl_test_f_mod
         do ii = 1, e0_length
           f_sum = f_sum + array_c64_1d(ii)
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_double * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_double * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c64_1d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -1733,7 +1737,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), dimension(:,:), allocatable :: array_l_2d
+        logical(flcl_ndarray_l_f_t), dimension(:,:), allocatable :: array_l_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -1776,7 +1780,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), dimension(:,:), allocatable :: array_i32_2d
+        integer(flcl_ndarray_i32_f_t), dimension(:,:), allocatable :: array_i32_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -1815,7 +1819,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), dimension(:,:), allocatable :: array_i64_2d
+        integer(flcl_ndarray_i64_f_t), dimension(:,:), allocatable :: array_i64_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -1873,7 +1877,7 @@ module flcl_test_f_mod
             f_sum = f_sum + array_r32_2d(ii,jj)
           end do
         end do
-        if ( abs(f_sum - c_sum ) < (precision_single * c_sum)) then
+        if ( abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum)) then
           write(*,*)'PASSED ndarray_r32_2d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -1912,7 +1916,7 @@ module flcl_test_f_mod
             f_sum = f_sum + array_r64_2d(ii,jj)
           end do
         end do
-        if ( abs(f_sum - c_sum ) < precision_double * c_sum ) then
+        if ( abs(f_sum - c_sum ) < ndarray_precision_single * c_sum ) then
           write(*,*)'PASSED ndarray_r64_2d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -1951,8 +1955,8 @@ module flcl_test_f_mod
             f_sum = f_sum + array_c32_2d(ii,jj)
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_single * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_single * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c32_2d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -1991,8 +1995,8 @@ module flcl_test_f_mod
             f_sum = f_sum + array_c64_2d(ii,jj)
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_double * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_double * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c64_2d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2012,7 +2016,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), dimension(:,:,:), allocatable :: array_l_3d
+        logical(flcl_ndarray_l_f_t), dimension(:,:,:), allocatable :: array_l_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2059,7 +2063,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), dimension(:,:,:), allocatable :: array_i32_3d
+        integer(flcl_ndarray_i32_f_t), dimension(:,:,:), allocatable :: array_i32_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2102,7 +2106,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), dimension(:,:,:), allocatable :: array_i64_3d
+        integer(flcl_ndarray_i64_f_t), dimension(:,:,:), allocatable :: array_i64_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2168,7 +2172,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < (precision_single * c_sum)) then
+        if ( abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum)) then
           write(*,*)'PASSED ndarray_r32_3d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2211,7 +2215,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < precision_double * c_sum ) then
+        if ( abs(f_sum - c_sum ) < ndarray_precision_single * c_sum ) then
           write(*,*)'PASSED ndarray_r64_3d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2254,8 +2258,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_single * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_single * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c32_3d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2298,8 +2302,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_double * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_double * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c64_3d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2319,7 +2323,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), dimension(:,:,:,:), allocatable :: array_l_4d
+        logical(flcl_ndarray_l_f_t), dimension(:,:,:,:), allocatable :: array_l_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2370,7 +2374,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), dimension(:,:,:,:), allocatable :: array_i32_4d
+        integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:), allocatable :: array_i32_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2417,7 +2421,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), dimension(:,:,:,:), allocatable :: array_i64_4d
+        integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:), allocatable :: array_i64_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2491,7 +2495,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < (precision_single * c_sum)) then
+        if ( abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum)) then
           write(*,*)'PASSED ndarray_r32_4d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2538,7 +2542,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < precision_double * c_sum ) then
+        if ( abs(f_sum - c_sum ) < ndarray_precision_single * c_sum ) then
           write(*,*)'PASSED ndarray_r64_4d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2585,8 +2589,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_single * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_single * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c32_4d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2633,8 +2637,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_double * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_double * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c64_4d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2654,7 +2658,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), dimension(:,:,:,:,:), allocatable :: array_l_5d
+        logical(flcl_ndarray_l_f_t), dimension(:,:,:,:,:), allocatable :: array_l_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2709,7 +2713,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), dimension(:,:,:,:,:), allocatable :: array_i32_5d
+        integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:,:), allocatable :: array_i32_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2760,7 +2764,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), dimension(:,:,:,:,:), allocatable :: array_i64_5d
+        integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:,:), allocatable :: array_i64_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -2842,7 +2846,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < (precision_single * c_sum)) then
+        if ( abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum)) then
           write(*,*)'PASSED ndarray_r32_5d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2851,7 +2855,8 @@ module flcl_test_f_mod
           write(*,*)'FAILED F ndarray_r32_5d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
-          write(*,*)'abs(f_sum - c_sum ) < (precision_single * c_sum) = ',(abs(f_sum - c_sum ) < (precision_single * c_sum))
+          write(*,*)'abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum) = ', &
+            & (abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum))
           ierr = flcl_test_fail
         end if
       end function test_ndarray_r32_5d
@@ -2894,7 +2899,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < precision_double * c_sum ) then
+        if ( abs(f_sum - c_sum ) < ndarray_precision_single * c_sum ) then
           write(*,*)'PASSED ndarray_r64_5d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2945,8 +2950,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_single * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_single * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c32_5d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -2997,8 +3002,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_double * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_double * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c64_5d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3018,7 +3023,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), dimension(:,:,:,:,:,:), allocatable :: array_l_6d
+        logical(flcl_ndarray_l_f_t), dimension(:,:,:,:,:,:), allocatable :: array_l_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -3077,7 +3082,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), dimension(:,:,:,:,:,:), allocatable :: array_i32_6d
+        integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:,:,:), allocatable :: array_i32_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -3132,7 +3137,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), dimension(:,:,:,:,:,:), allocatable :: array_i64_6d
+        integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:,:,:), allocatable :: array_i64_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -3223,7 +3228,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < (precision_single * c_sum)) then
+        if ( abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum)) then
           write(*,*)'PASSED ndarray_r32_6d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3232,7 +3237,8 @@ module flcl_test_f_mod
           write(*,*)'FAILED F ndarray_r32_6d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
-          write(*,*)'abs(f_sum - c_sum ) < (precision_single * c_sum) = ',(abs(f_sum - c_sum ) < (precision_single * c_sum))
+          write(*,*)'abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum) = ', &
+            & (abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum))
           ierr = flcl_test_fail
         end if
       end function test_ndarray_r32_6d
@@ -3279,7 +3285,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < precision_double * c_sum ) then
+        if ( abs(f_sum - c_sum ) < ndarray_precision_single * c_sum ) then
           write(*,*)'PASSED ndarray_r64_6d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3334,8 +3340,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_single * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_single * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c32_6d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3390,8 +3396,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_double * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_double * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c64_6d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3411,7 +3417,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), dimension(:,:,:,:,:,:,:), allocatable :: array_l_7d
+        logical(flcl_ndarray_l_f_t), dimension(:,:,:,:,:,:,:), allocatable :: array_l_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -3474,7 +3480,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), dimension(:,:,:,:,:,:,:), allocatable :: array_i32_7d
+        integer(flcl_ndarray_i32_f_t), dimension(:,:,:,:,:,:,:), allocatable :: array_i32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -3533,7 +3539,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), dimension(:,:,:,:,:,:,:), allocatable :: array_i64_7d
+        integer(flcl_ndarray_i64_f_t), dimension(:,:,:,:,:,:,:), allocatable :: array_i64_7d
         integer :: ii, jj, kk, ll, mm, nn,oo
         integer(c_size_t) :: f_sum = 0
         integer(c_size_t) :: c_sum = 0
@@ -3631,7 +3637,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < (precision_single * c_sum)) then
+        if ( abs(f_sum - c_sum ) < (ndarray_precision_single * c_sum)) then
           write(*,*)'PASSED ndarray_r32_7d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3690,7 +3696,7 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if ( abs(f_sum - c_sum ) < precision_double * c_sum ) then
+        if ( abs(f_sum - c_sum ) < ndarray_precision_single * c_sum ) then
           write(*,*)'PASSED ndarray_r64_7d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3749,8 +3755,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_single * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_single * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c32_7d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3809,8 +3815,8 @@ module flcl_test_f_mod
             end do
           end do
         end do
-        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > precision_double * FLCL_REALPART(f_sum) .or. &
-          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > precision_double * FLCL_IMAGPART(f_sum) ) then
+        if (FLCL_REALPART(f_sum) - FLCL_REALPART(c_sum) > ndarray_precision_single * FLCL_REALPART(f_sum) .or. &
+          & FLCL_IMAGPART(f_sum) - FLCL_IMAGPART(c_sum) > ndarray_precision_single * FLCL_IMAGPART(f_sum) ) then
           write(*,*)'PASSED ndarray_c64_7d'
           write(*,*)'f_sum = ',f_sum
           write(*,*)'c_sum = ',c_sum
@@ -3830,7 +3836,7 @@ module flcl_test_f_mod
         use :: flcl_view_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:)  :: array_l_1d
+        logical(flcl_view_l_f_t), pointer, dimension(:)  :: array_l_1d
         type(view_l_1d_t) :: v_array_l_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
@@ -3874,7 +3880,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:)  :: array_i32_1d
+        integer(flcl_view_i32_f_t), pointer, dimension(:)  :: array_i32_1d
         type(view_i32_1d_t) :: v_array_i32_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
@@ -3913,7 +3919,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:)  :: array_i64_1d
+        integer(flcl_view_i64_f_t), pointer, dimension(:)  :: array_i64_1d
         type(view_i64_1d_t) :: v_array_i64_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
@@ -3969,7 +3975,7 @@ module flcl_test_f_mod
           do ii = 1, e0_length
             f_sum = f_sum + array_r32_1d(ii)
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r32_1d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4008,7 +4014,7 @@ module flcl_test_f_mod
           do ii = 1, e0_length
             f_sum = f_sum + array_r64_1d(ii)
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r64_1d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4030,7 +4036,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:)  :: array_l_2d
+        logical(flcl_view_l_f_t), pointer, dimension(:,:)  :: array_l_2d
         type(view_l_2d_t) :: v_array_l_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
@@ -4077,7 +4083,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:)  :: array_i32_2d
+        integer(flcl_view_i32_f_t), pointer, dimension(:,:)  :: array_i32_2d
         type(view_i32_2d_t) :: v_array_i32_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
@@ -4120,7 +4126,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:)  :: array_i64_2d
+        integer(flcl_view_i64_f_t), pointer, dimension(:,:)  :: array_i64_2d
         type(view_i64_2d_t) :: v_array_i64_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
@@ -4184,7 +4190,7 @@ module flcl_test_f_mod
               f_sum = f_sum + array_r32_2d(ii,jj)
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r32_2d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4227,7 +4233,7 @@ module flcl_test_f_mod
               f_sum = f_sum + array_r64_2d(ii,jj)
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r64_2d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4249,7 +4255,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:)  :: array_l_3d
+        logical(flcl_view_l_f_t), pointer, dimension(:,:,:)  :: array_l_3d
         type(view_l_3d_t) :: v_array_l_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
@@ -4300,7 +4306,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:)  :: array_i32_3d
+        integer(flcl_view_i32_f_t), pointer, dimension(:,:,:)  :: array_i32_3d
         type(view_i32_3d_t) :: v_array_i32_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
@@ -4347,7 +4353,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:)  :: array_i64_3d
+        integer(flcl_view_i64_f_t), pointer, dimension(:,:,:)  :: array_i64_3d
         type(view_i64_3d_t) :: v_array_i64_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
@@ -4419,7 +4425,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r32_3d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4466,7 +4472,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r64_3d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4488,7 +4494,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:)  :: array_l_4d
+        logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:)  :: array_l_4d
         type(view_l_4d_t) :: v_array_l_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
@@ -4543,7 +4549,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:)  :: array_i32_4d
+        integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:)  :: array_i32_4d
         type(view_i32_4d_t) :: v_array_i32_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
@@ -4594,7 +4600,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:)  :: array_i64_4d
+        integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:)  :: array_i64_4d
         type(view_i64_4d_t) :: v_array_i64_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
@@ -4674,7 +4680,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r32_4d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4725,7 +4731,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r64_4d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -4747,7 +4753,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:,:)  :: array_l_5d
+        logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:)  :: array_l_5d
         type(view_l_5d_t) :: v_array_l_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
@@ -4807,7 +4813,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:,:)  :: array_i32_5d
+        integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:)  :: array_i32_5d
         type(view_i32_5d_t) :: v_array_i32_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
@@ -4863,7 +4869,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:,:)  :: array_i64_5d
+        integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:)  :: array_i64_5d
         type(view_i64_5d_t) :: v_array_i64_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
@@ -4953,7 +4959,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r32_5d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5009,7 +5015,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r64_5d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5031,7 +5037,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:,:,:)  :: array_l_6d
+        logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_l_6d
         type(view_l_6d_t) :: v_array_l_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
@@ -5095,7 +5101,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:,:,:)  :: array_i32_6d
+        integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i32_6d
         type(view_i32_6d_t) :: v_array_i32_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
@@ -5155,7 +5161,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:,:,:)  :: array_i64_6d
+        integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i64_6d
         type(view_i64_6d_t) :: v_array_i64_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
@@ -5253,7 +5259,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r32_6d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5313,7 +5319,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r64_6d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5335,7 +5341,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:,:,:,:)  :: array_l_7d
+        logical(flcl_view_l_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_l_7d
         type(view_l_7d_t) :: v_array_l_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
@@ -5403,7 +5409,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i32_7d
+        integer(flcl_view_i32_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i32_7d
         type(view_i32_7d_t) :: v_array_i32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
@@ -5467,7 +5473,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i64_7d
+        integer(flcl_view_i64_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i64_7d
         type(view_i64_7d_t) :: v_array_i64_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
@@ -5573,7 +5579,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r32_7d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5637,7 +5643,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (view_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_view_r64_7d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5659,7 +5665,7 @@ module flcl_test_f_mod
         use :: flcl_view_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:)  :: array_l_1d
+        logical(flcl_dualview_l_f_t), pointer, dimension(:)  :: array_l_1d
         type(dualview_l_1d_t) :: v_array_l_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
@@ -5703,7 +5709,7 @@ module flcl_test_f_mod
         use :: flcl_view_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:)  :: array_i32_1d
+        integer(flcl_dualview_i32_f_t), pointer, dimension(:)  :: array_i32_1d
         type(dualview_i32_1d_t) :: v_array_i32_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
@@ -5742,7 +5748,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:)  :: array_i64_1d
+        integer(flcl_dualview_i64_f_t), pointer, dimension(:)  :: array_i64_1d
         type(dualview_i64_1d_t) :: v_array_i64_1d
         integer :: ii
         integer(c_size_t) :: f_sum = 0
@@ -5798,7 +5804,7 @@ module flcl_test_f_mod
           do ii = 1, e0_length
             f_sum = f_sum + array_r32_1d(ii)
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r32_1d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5837,7 +5843,7 @@ module flcl_test_f_mod
           do ii = 1, e0_length
             f_sum = f_sum + array_r64_1d(ii)
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r64_1d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -5859,7 +5865,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:)  :: array_l_2d
+        logical(flcl_dualview_l_f_t), pointer, dimension(:,:)  :: array_l_2d
         type(dualview_l_2d_t) :: v_array_l_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
@@ -5906,7 +5912,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:)  :: array_i32_2d
+        integer(flcl_dualview_i32_f_t), pointer, dimension(:,:)  :: array_i32_2d
         type(dualview_i32_2d_t) :: v_array_i32_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
@@ -5949,7 +5955,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:)  :: array_i64_2d
+        integer(flcl_dualview_i64_f_t), pointer, dimension(:,:)  :: array_i64_2d
         type(dualview_i64_2d_t) :: v_array_i64_2d
         integer :: ii, jj
         integer(c_size_t) :: f_sum = 0
@@ -6013,7 +6019,7 @@ module flcl_test_f_mod
               f_sum = f_sum + array_r32_2d(ii,jj)
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r32_2d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6056,7 +6062,7 @@ module flcl_test_f_mod
               f_sum = f_sum + array_r64_2d(ii,jj)
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r64_2d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6078,7 +6084,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:)  :: array_l_3d
+        logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:)  :: array_l_3d
         type(dualview_l_3d_t) :: v_array_l_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
@@ -6129,7 +6135,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:)  :: array_i32_3d
+        integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:)  :: array_i32_3d
         type(dualview_i32_3d_t) :: v_array_i32_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
@@ -6176,7 +6182,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:)  :: array_i64_3d
+        integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:)  :: array_i64_3d
         type(dualview_i64_3d_t) :: v_array_i64_3d
         integer :: ii, jj, kk
         integer(c_size_t) :: f_sum = 0
@@ -6248,7 +6254,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r32_3d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6295,7 +6301,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r64_3d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6317,7 +6323,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:)  :: array_l_4d
+        logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:)  :: array_l_4d
         type(dualview_l_4d_t) :: v_array_l_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
@@ -6372,7 +6378,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:)  :: array_i32_4d
+        integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:)  :: array_i32_4d
         type(dualview_i32_4d_t) :: v_array_i32_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
@@ -6423,7 +6429,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:)  :: array_i64_4d
+        integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:)  :: array_i64_4d
         type(dualview_i64_4d_t) :: v_array_i64_4d
         integer :: ii, jj, kk, ll
         integer(c_size_t) :: f_sum = 0
@@ -6503,7 +6509,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r32_4d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6554,7 +6560,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r64_4d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6576,7 +6582,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:,:)  :: array_l_5d
+        logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:)  :: array_l_5d
         type(dualview_l_5d_t) :: v_array_l_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
@@ -6636,7 +6642,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:,:)  :: array_i32_5d
+        integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:)  :: array_i32_5d
         type(dualview_i32_5d_t) :: v_array_i32_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
@@ -6692,7 +6698,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:,:)  :: array_i64_5d
+        integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:)  :: array_i64_5d
         type(dualview_i64_5d_t) :: v_array_i64_5d
         integer :: ii, jj, kk, ll, mm
         integer(c_size_t) :: f_sum = 0
@@ -6782,7 +6788,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r32_5d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6838,7 +6844,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r64_5d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -6860,7 +6866,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:,:,:)  :: array_l_6d
+        logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_l_6d
         type(dualview_l_6d_t) :: v_array_l_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
@@ -6924,7 +6930,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:,:,:)  :: array_i32_6d
+        integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i32_6d
         type(dualview_i32_6d_t) :: v_array_i32_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
@@ -6984,7 +6990,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:,:,:)  :: array_i64_6d
+        integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:)  :: array_i64_6d
         type(dualview_i64_6d_t) :: v_array_i64_6d
         integer :: ii, jj, kk, ll, mm, nn
         integer(c_size_t) :: f_sum = 0
@@ -7082,7 +7088,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r32_6d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -7142,7 +7148,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r64_6d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -7164,7 +7170,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        logical(c_bool), pointer, dimension(:,:,:,:,:,:,:)  :: array_l_7d
+        logical(flcl_dualview_l_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_l_7d
         type(dualview_l_7d_t) :: v_array_l_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
@@ -7232,7 +7238,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int32_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i32_7d
+        integer(flcl_dualview_i32_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i32_7d
         type(dualview_i32_7d_t) :: v_array_i32_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
@@ -7296,7 +7302,7 @@ module flcl_test_f_mod
         use :: flcl_mod
         implicit none
 
-        integer(c_int64_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i64_7d
+        integer(flcl_dualview_i64_f_t), pointer, dimension(:,:,:,:,:,:,:)  :: array_i64_7d
         type(dualview_i64_7d_t) :: v_array_i64_7d
         integer :: ii, jj, kk, ll, mm, nn, oo
         integer(c_size_t) :: f_sum = 0
@@ -7402,7 +7408,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_single * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r32_7d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum
@@ -7466,7 +7472,7 @@ module flcl_test_f_mod
               end do
             end do
           end do
-          if ( abs(f_sum - c_sum ) < (precision_double * c_sum) ) then
+          if ( abs(f_sum - c_sum ) < (dualview_precision_single * c_sum) ) then
             write(*,*)'PASSED kokkos_allocate_dualview_r64_7d'
             write(*,*)'f_sum = ',f_sum
             write(*,*)'c_sum = ',c_sum

--- a/test/flcl-test-f.F90
+++ b/test/flcl-test-f.F90
@@ -53,7 +53,6 @@ module flcl_test_f_mod
   use, intrinsic :: iso_fortran_env
 
   use :: flcl_mod
-  use :: flcl_types_f_mod
 
   implicit none
   

--- a/test/flcl-test-f.F90
+++ b/test/flcl-test-f.F90
@@ -53,18 +53,19 @@ module flcl_test_f_mod
   use, intrinsic :: iso_fortran_env
 
   use :: flcl_mod
+  use :: flcl_types_f_mod
 
   implicit none
   
-  integer(c_size_t), parameter :: e0_length = 8
-  integer(c_size_t), parameter :: e1_length = 7
-  integer(c_size_t), parameter :: e2_length = 6
-  integer(c_size_t), parameter :: e3_length = 5
-  integer(c_size_t), parameter :: e4_length = 4
-  integer(c_size_t), parameter :: e5_length = 3
-  integer(c_size_t), parameter :: e6_length = 2
-  logical(c_bool), parameter :: logical_pre = .true.
-  logical(c_bool), parameter :: logical_post = .false.
+  integer(flcl_ndarray_index_f_t), parameter :: e0_length = 8
+  integer(flcl_ndarray_index_f_t), parameter :: e1_length = 7
+  integer(flcl_ndarray_index_f_t), parameter :: e2_length = 6
+  integer(flcl_ndarray_index_f_t), parameter :: e3_length = 5
+  integer(flcl_ndarray_index_f_t), parameter :: e4_length = 4
+  integer(flcl_ndarray_index_f_t), parameter :: e5_length = 3
+  integer(flcl_ndarray_index_f_t), parameter :: e6_length = 2
+  logical(flcl_ndarray_l_f_t), parameter :: logical_pre = .true.
+  logical(flcl_ndarray_l_f_t), parameter :: logical_post = .false.
 
   enum, bind(c)
     enumerator :: flcl_test_pass = 0

--- a/test/test_ndarray_c32_1d.f90
+++ b/test/test_ndarray_c32_1d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c32_1d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c32_2d.f90
+++ b/test/test_ndarray_c32_2d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c32_2d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c32_3d.f90
+++ b/test/test_ndarray_c32_3d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c32_3d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c32_4d.f90
+++ b/test/test_ndarray_c32_4d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c32_4d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c32_5d.f90
+++ b/test/test_ndarray_c32_5d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c32_5d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c32_6d.f90
+++ b/test/test_ndarray_c32_6d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c32_6d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c32_7d.f90
+++ b/test/test_ndarray_c32_7d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c32_7d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c64_1d.f90
+++ b/test/test_ndarray_c64_1d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c64_1d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c64_2d.f90
+++ b/test/test_ndarray_c64_2d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c64_2d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c64_3d.f90
+++ b/test/test_ndarray_c64_3d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c64_3d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c64_4d.f90
+++ b/test/test_ndarray_c64_4d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c64_4d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c64_5d.f90
+++ b/test/test_ndarray_c64_5d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c64_5d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c64_6d.f90
+++ b/test/test_ndarray_c64_6d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c64_6d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_c64_7d.f90
+++ b/test/test_ndarray_c64_7d.f90
@@ -45,7 +45,7 @@ program test_ndarray_c64_7d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i32_1d.f90
+++ b/test/test_ndarray_i32_1d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i32_1d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i32_2d.f90
+++ b/test/test_ndarray_i32_2d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i32_2d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i32_3d.f90
+++ b/test/test_ndarray_i32_3d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i32_3d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i32_4d.f90
+++ b/test/test_ndarray_i32_4d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i32_4d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i32_5d.f90
+++ b/test/test_ndarray_i32_5d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i32_5d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i32_6d.f90
+++ b/test/test_ndarray_i32_6d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i32_6d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i32_7d.f90
+++ b/test/test_ndarray_i32_7d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i32_7d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i64_1d.f90
+++ b/test/test_ndarray_i64_1d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i64_1d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i64_2d.f90
+++ b/test/test_ndarray_i64_2d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i64_2d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i64_3d.f90
+++ b/test/test_ndarray_i64_3d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i64_3d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i64_4d.f90
+++ b/test/test_ndarray_i64_4d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i64_4d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i64_5d.f90
+++ b/test/test_ndarray_i64_5d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i64_5d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i64_6d.f90
+++ b/test/test_ndarray_i64_6d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i64_6d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_i64_7d.f90
+++ b/test/test_ndarray_i64_7d.f90
@@ -45,7 +45,7 @@ program test_ndarray_i64_7d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_l_1d.f90
+++ b/test/test_ndarray_l_1d.f90
@@ -45,7 +45,7 @@ program test_ndarray_l_1d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_l_2d.f90
+++ b/test/test_ndarray_l_2d.f90
@@ -45,7 +45,7 @@ program test_ndarray_l_2d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_l_3d.f90
+++ b/test/test_ndarray_l_3d.f90
@@ -45,7 +45,7 @@ program test_ndarray_l_3d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_l_4d.f90
+++ b/test/test_ndarray_l_4d.f90
@@ -45,7 +45,7 @@ program test_ndarray_l_4d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_l_5d.f90
+++ b/test/test_ndarray_l_5d.f90
@@ -45,7 +45,7 @@ program test_ndarray_l_5d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_l_6d.f90
+++ b/test/test_ndarray_l_6d.f90
@@ -45,7 +45,7 @@ program test_ndarray_l_6d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_l_7d.f90
+++ b/test/test_ndarray_l_7d.f90
@@ -45,7 +45,7 @@ program test_ndarray_l_7d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r32_1d.f90
+++ b/test/test_ndarray_r32_1d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r32_1d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r32_2d.f90
+++ b/test/test_ndarray_r32_2d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r32_2d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r32_3d.f90
+++ b/test/test_ndarray_r32_3d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r32_3d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r32_4d.f90
+++ b/test/test_ndarray_r32_4d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r32_4d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r32_5d.f90
+++ b/test/test_ndarray_r32_5d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r32_5d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r32_6d.f90
+++ b/test/test_ndarray_r32_6d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r32_6d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r32_7d.f90
+++ b/test/test_ndarray_r32_7d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r32_7d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r64_1d.f90
+++ b/test/test_ndarray_r64_1d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r64_1d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r64_2d.f90
+++ b/test/test_ndarray_r64_2d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r64_2d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r64_3d.f90
+++ b/test/test_ndarray_r64_3d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r64_3d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r64_4d.f90
+++ b/test/test_ndarray_r64_4d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r64_4d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r64_5d.f90
+++ b/test/test_ndarray_r64_5d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r64_5d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r64_6d.f90
+++ b/test/test_ndarray_r64_6d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r64_6d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 

--- a/test/test_ndarray_r64_7d.f90
+++ b/test/test_ndarray_r64_7d.f90
@@ -45,7 +45,7 @@ program test_ndarray_r64_7d_main
   
     implicit none
   
-    integer(c_size_t) :: ierr = 0
+    integer :: ierr = 0
   
     call kokkos_initialize_without_args()
 


### PR DESCRIPTION
- Replaces all the hardcoded types that underpin ndarray, view, and dualview implementations and unit tests.
- - This supports the ability to change the underlying scalar types used therein, but they must still match between C, Fortran, and be supported by ISO_C_BINDING so this is not an unlimited list. However, it is now possible to test against.