### PR TITLE
Fix examples 02 and 03 for CUDA backend

### DIFF
--- a/examples/02-axpy-dualview/axpy-dualview-cxx.cc
+++ b/examples/02-axpy-dualview/axpy-dualview-cxx.cc
@@ -53,11 +53,12 @@ extern "C" {
     y.template sync<typename view_type::execution_space>();
     x.template sync<typename view_type::execution_space>();
 
+    double d_alpha = *alpha;
     Kokkos::parallel_for( "axpy", y.extent(0), KOKKOS_LAMBDA( const size_t idx)
     {
-      y.d_view(idx) += *alpha * x.d_view(idx);
+      y.d_view(idx) += d_alpha * x.d_view(idx);
     });
-  
+
     y.template modify<typename view_type::execution_space>();
     x.template modify<typename view_type::execution_space>();
     y.template sync<typename view_type::host_mirror_space>();

--- a/examples/03-axpy-view/axpy-view-cxx.cc
+++ b/examples/03-axpy-view/axpy-view-cxx.cc
@@ -48,10 +48,14 @@ extern "C" {
     view_type y = **v_y;
     view_type x = **v_x;
 
+    double d_alpha = *alpha;
     Kokkos::parallel_for( "axpy", y.extent(0), KOKKOS_LAMBDA( const size_t idx)
     {
-      y(idx) += *alpha * x(idx);
+      y(idx) += d_alpha * x(idx);
     });
+
+    // make sure data can be reused on host
+    Kokkos::fence();
 
     return;
   }


### PR DESCRIPTION
This fix issue #58 (make sure examples 02 and 03 can run when Kokkos::Cuda backend is activated)

- both examples were dereferencing a host pointer inside a device kernel
- in example 03, a Kokkos fence was missing; needed to be sure that results data can be safely re-used on host.