### PR TITLE
Update project version and add error message when enabling the tests/examples without PIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ option(FLCL_BUILD_EXAMPLES "Build examples" ON)
 option(FLCL_BUILD_TESTS "Build tests" ON)
 
 # The tests and the examples need to be built with PIE because they link against GLICXX
-if (${FLCL_BUILD_TESTS} OR ${FLCL_BUILD_TESTS})
-  if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE OR NOT ${CMAKE_POSITION_INDEPENDENT_CODE})
+if (${FLCL_BUILD_EXAMPLES} OR ${FLCL_BUILD_TESTS})
+  if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
     message(FATAL_ERROR "Enabling the tests or the examples require configuring with -DCMAKE_POSITION_INDEPENDENT_CODE=ON")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-project(flcl VERSION 0.5.0 LANGUAGES Fortran C CXX)
+project(flcl VERSION 0.99.99 LANGUAGES Fortran C CXX)
 
 if (NOT CMAKE_BUILD_TYPE)
   set(DEFAULT_BUILD_TYPE "RelWithDebInfo")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(FLCL_BUILD_EXAMPLES "Build examples" ON)
 option(FLCL_BUILD_TESTS "Build tests" ON)
 
 # The tests and the examples need to be built with PIE because they link against GLICXX
-if (${FLCL_BUILD_EXAMPLES} OR ${FLCL_BUILD_TESTS})
+if (FLCL_BUILD_EXAMPLES OR FLCL_BUILD_TESTS)
   if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
     message(FATAL_ERROR "Enabling the tests or the examples require configuring with -DCMAKE_POSITION_INDEPENDENT_CODE=ON")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,19 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 
+# FIXME This was set in a XL-related commit:
+# https://github.com/kokkos/kokkos-fortran-interop/commit/f232302284400a90410a36edb14f538c20b8a71b
+# We need to check if it is still necessary
 set(BUILD_SHARED_LIBS OFF)
 option(FLCL_BUILD_EXAMPLES "Build examples" ON)
 option(FLCL_BUILD_TESTS "Build tests" ON)
+
+# The tests and the examples need to be built with PIE because they link against GLICXX
+if (${FLCL_BUILD_TESTS} OR ${FLCL_BUILD_TESTS})
+  if (NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE OR NOT ${CMAKE_POSITION_INDEPENDENT_CODE})
+    message(FATAL_ERROR "Enabling the tests or the examples require configuring with -DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+  endif()
+endif()
 
 include(CMakeDetermineFortranCompiler)
 include(CMakeDetermineCCompiler)


### PR DESCRIPTION
This PR does two things:
 1. Update the projection version on develop to 0.99.99.  We released version 0.99 three years ago.
 2. Add an error message if the tests/examples are enabled but `-DCMAKE_POSITION_INDEPENDENT_CODE` is not set.

The build system needs an update but first I want to setup a new CI. 