### PR TITLE
Add Jenkins CI

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -26,21 +26,21 @@ pipeline {
             sh '''rm -rf kokkos &&
                   git clone --branch 4.4.01 --depth 1 https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
-                  mkdir build && cd build && \
-                  cmake \
+                  cmake -B build_kokkos \
                     -DCMAKE_CXX_COMPILER=$WORKSPACE/kokkos/bin/nvcc_wrapper \
                     -DCMAKE_CXX_EXTENSIONS=OFF \
                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                     -DKokkos_ENABLE_CUDA=ON \
-                  .. && \
-                  make -j8 && make install'''
-            sh '''rm -rf build && mkdir -p build && cd build && \
-                  cmake \
-                    -DCMAKE_CXX_COMPILER=$WORKSPACE/kokkos/bin/nvcc_wrapper \
+                    -DCMAKE_INSTALL_PREFIX=/opt/kokkos && \
+                  cmake --build build_kokkos -j8 && \
+                  cmake --install build_kokkos'''
+            sh '''rm -rf build && \
+                  cmake -B build_interop \
+                    -DCMAKE_CXX_COMPILER=/opt/kokkos/bin/nvcc_wrapper \
                     -DCMAKE_CXX_EXTENSIONS=OFF \
-                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  .. && \
-                  make -j8 && ctest --verbose'''
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
+                  cmake --build build_interop -j8 && \
+                  ctest --test-dir build_interop --verbose'''
           }
         }
 
@@ -57,21 +57,21 @@ pipeline {
             sh '''rm -rf kokkos &&
                   git clone --branch 4.4.01 --depth 1 https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
-                  mkdir build && cd build && \
-                  cmake \
+                  cmake -B build_kokkos \
                     -DCMAKE_CXX_COMPILER=hipcc \
                     -DCMAKE_CXX_EXTENSIONS=OFF \
                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                     -DKokkos_ENABLE_HIP=ON \
-                  .. && \
-                  make -j8 && make install'''
-            sh '''rm -rf build && mkdir -p build && cd build && \
-                  cmake \
+                    -DCMAKE_INSTALL_PREFIX=/opt/kokkos && \
+                  cmake --build build_kokkos -j8 && \
+                  cmake --install build_kokkos'''
+            sh '''rm -rf build && \
+                  cmake -B build_interop \
                     -DCMAKE_CXX_COMPILER=hipcc \
                     -DCMAKE_CXX_EXTENSIONS=OFF \
-                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  .. && \
-                  make -j8 && ctest --verbose'''
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
+                  cmake --build build_interop -j8 && \
+                  ctest --test-dir build_interop --verbose'''
           }
         }
 
@@ -93,19 +93,19 @@ pipeline {
             sh '''rm -rf kokkos &&
                   git clone --branch 4.4.01 --depth 1 https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
-                  mkdir build && cd build && \
-                  cmake \
+                  cmake -B build_kokkos \
                     -DCMAKE_CXX_EXTENSIONS=OFF \
                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                     -DKokkos_ENABLE_OPENMP=ON \
-                  .. && \
-                  make -j8 && make install'''
-            sh '''rm -rf build && mkdir -p build && cd build && \
-                  cmake \
+                    -DCMAKE_INSTALL_PREFIX=/opt/kokkos && \
+                  cmake --build build_kokkos -j8 && \
+                  cmake --install build_kokkos'''
+            sh '''rm -rf build && \
+                  cmake -B build_interop \
                     -DCMAKE_CXX_EXTENSIONS=OFF \
-                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-                  .. && \
-                  make -j8 && ctest --verbose'''
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON && \
+                  cmake --build build_interop -j8 && \
+                  ctest --test-dir build_interop --verbose'''
           }
         }
       }

--- a/.jenkins
+++ b/.jenkins
@@ -24,7 +24,7 @@ pipeline {
           }
           steps {
             sh '''rm -rf kokkos &&
-                  git clone https://github.com/kokkos/kokkos.git && \
+                  git clone --branch 4.4.01 --single-branch https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
                   mkdir build && cd build && \
                   cmake \
@@ -55,7 +55,7 @@ pipeline {
           }
           steps {
             sh '''rm -rf kokkos &&
-                  git clone https://github.com/kokkos/kokkos.git && \
+                  git clone --branch 4.4.01 --single-branch https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
                   mkdir build && cd build && \
                   cmake \
@@ -91,7 +91,7 @@ pipeline {
           }
           steps {
             sh '''rm -rf kokkos &&
-                  git clone https://github.com/kokkos/kokkos.git && \
+                  git clone --branch 4.4.01 --single-branch https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
                   mkdir build && cd build && \
                   cmake \

--- a/.jenkins
+++ b/.jenkins
@@ -24,7 +24,7 @@ pipeline {
           }
           steps {
             sh '''rm -rf kokkos &&
-                  git clone --branch 4.4.01 --single-branch https://github.com/kokkos/kokkos.git && \
+                  git clone --branch 4.4.01 --depth 1 https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
                   mkdir build && cd build && \
                   cmake \
@@ -55,7 +55,7 @@ pipeline {
           }
           steps {
             sh '''rm -rf kokkos &&
-                  git clone --branch 4.4.01 --single-branch https://github.com/kokkos/kokkos.git && \
+                  git clone --branch 4.4.01 --depth 1 https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
                   mkdir build && cd build && \
                   cmake \
@@ -91,7 +91,7 @@ pipeline {
           }
           steps {
             sh '''rm -rf kokkos &&
-                  git clone --branch 4.4.01 --single-branch https://github.com/kokkos/kokkos.git && \
+                  git clone --branch 4.4.01 --depth 1 https://github.com/kokkos/kokkos.git && \
                   cd kokkos && \
                   mkdir build && cd build && \
                   cmake \

--- a/.jenkins
+++ b/.jenkins
@@ -1,0 +1,114 @@
+pipeline {
+  agent none
+
+  options {
+    disableConcurrentBuilds(abortPrevious: true)
+    timeout(time: 6, unit: 'HOURS')
+  }
+
+  triggers {
+    issueCommentTrigger('.*test this please.*')
+  }
+
+  stages {
+    stage('Build') {
+      parallel {
+        stage('CUDA-12.6-NVCC') {
+          agent {
+              dockerfile {
+                  filename 'Dockerfile.nvcc'
+                  dir 'scripts'
+                  label 'nvidia-docker'
+                  args '--env NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES'
+              }
+          }
+          steps {
+            sh '''rm -rf kokkos &&
+                  git clone https://github.com/kokkos/kokkos.git && \
+                  cd kokkos && \
+                  mkdir build && cd build && \
+                  cmake \
+                    -DCMAKE_CXX_COMPILER=$WORKSPACE/kokkos/bin/nvcc_wrapper \
+                    -DCMAKE_CXX_EXTENSIONS=OFF \
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                    -DKokkos_ENABLE_CUDA=ON \
+                  .. && \
+                  make -j8 && make install'''
+            sh '''rm -rf build && mkdir -p build && cd build && \
+                  cmake \
+                    -DCMAKE_CXX_COMPILER=$WORKSPACE/kokkos/bin/nvcc_wrapper \
+                    -DCMAKE_CXX_EXTENSIONS=OFF \
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                  .. && \
+                  make -j8 && ctest --verbose'''
+          }
+        }
+
+        stage('HIP-ROCm-6.2') {
+          agent {
+            dockerfile {
+              filename 'Dockerfile.hipcc'
+              dir 'scripts'
+              label 'rocm-docker'
+              args '--device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --env HIP_VISIBLE_DEVICES=$HIP_VISIBLE_DEVICES'
+            }
+          }
+          steps {
+            sh '''rm -rf kokkos &&
+                  git clone https://github.com/kokkos/kokkos.git && \
+                  cd kokkos && \
+                  mkdir build && cd build && \
+                  cmake \
+                    -DCMAKE_CXX_COMPILER=hipcc \
+                    -DCMAKE_CXX_EXTENSIONS=OFF \
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                    -DKokkos_ENABLE_HIP=ON \
+                  .. && \
+                  make -j8 && make install'''
+            sh '''rm -rf build && mkdir -p build && cd build && \
+                  cmake \
+                    -DCMAKE_CXX_COMPILER=hipcc \
+                    -DCMAKE_CXX_EXTENSIONS=OFF \
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                  .. && \
+                  make -j8 && ctest --verbose'''
+          }
+        }
+
+        stage('GCC-14.2') {
+          agent {
+            dockerfile {
+              filename 'Dockerfile.gcc'
+              dir 'scripts'
+              label 'docker'
+            }
+          }
+          environment {
+            OMP_NUM_THREADS = 8
+            OMP_NESTED = 'true'
+            OMP_MAX_ACTIVE_LEVELS = 3
+            OMP_PROC_BIND = 'true'
+          }
+          steps {
+            sh '''rm -rf kokkos &&
+                  git clone https://github.com/kokkos/kokkos.git && \
+                  cd kokkos && \
+                  mkdir build && cd build && \
+                  cmake \
+                    -DCMAKE_CXX_EXTENSIONS=OFF \
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                    -DKokkos_ENABLE_OPENMP=ON \
+                  .. && \
+                  make -j8 && make install'''
+            sh '''rm -rf build && mkdir -p build && cd build && \
+                  cmake \
+                    -DCMAKE_CXX_EXTENSIONS=OFF \
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+                  .. && \
+                  make -j8 && ctest --verbose'''
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/Dockerfile.gcc
+++ b/scripts/Dockerfile.gcc
@@ -1,0 +1,7 @@
+FROM gcc:14.2
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    cmake \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/scripts/Dockerfile.hipcc
+++ b/scripts/Dockerfile.hipcc
@@ -1,0 +1,11 @@
+FROM rocm/dev-ubuntu-22.04:6.2-complete
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    cmake \
+    gfortran \
+    git \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=/opt/rocm/bin:$PATH

--- a/scripts/Dockerfile.nvcc
+++ b/scripts/Dockerfile.nvcc
@@ -1,0 +1,9 @@
+FROM nvidia/cuda:12.6.1-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    cmake \
+    gfortran \
+    git \
+    && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR adds Jenkins CI to the repo. I've decided to only test the latest compilers. We can add more configuration if we want later on. 
I quickly tried to merge the three Dockerfile into one but HIP and CUDA require to install gfortran and weirdly the gcc Dockerfile does not work in this case. I also had an issue with `rocThust` when combining everything. Merging the three Dockerfile could probably be done but I didn't bother. I'll do it if someone asks.