### PR TITLE
Remove useless includes in CMakeLists.txt and move include(ctest)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,9 @@ add_library(flcl-fortran
         src/flcl-f.f90
         src/flcl-util-kokkos-f.f90
 )
-#standards compliance section
+# standards compliance section
+# There is no CMake function to enforce the language standard in Fortran.
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/22235
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
     # fully enable F2008, per IBM article: https://www.ibm.com/docs/en/xl-fortran-linux/16.1.1?topic=scenarios-compiling-fortran-2008-programs
     # also enable polymorphic feature (-qxlf2003=polymorphic) to support the view/dualview types to enable type disambiguation in generic interfaces

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,6 @@ find_package(Kokkos REQUIRED)
 
 include(GNUInstallDirs)
 
-if (FLCL_BUILD_TESTS)
-  include(CTest)
-endif()
-
 add_link_options(LINKER:--disable-new-dtags)
 
 #flcl-fortran library
@@ -160,6 +156,7 @@ install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod/" DESTINATION "${CMAKE_INSTAL
 
 #unit testing section and toggle
 if(FLCL_BUILD_TESTS)
+  include(CTest)
   add_subdirectory(test)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,15 +25,7 @@ if (FLCL_BUILD_EXAMPLES OR FLCL_BUILD_TESTS)
   endif()
 endif()
 
-include(CMakeDetermineFortranCompiler)
-include(CMakeDetermineCCompiler)
-include(CMakeDetermineCXXCompiler)
-
 find_package(Kokkos REQUIRED)
-
-include(CheckFortranCompilerFlag)
-include(CheckCXXCompilerFlag)
-include(CheckCCompilerFlag)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
This is the first of several PRs that refactor the build system. In this one, I have removed useless include and move include(ctest). 

I have also added a comment about the fact that `CMAKE_FORTRAN_STANDARD` does not exist. If you follow the link, they say that by default fortran compilers use the newest standard. When we set the standard, we restrict the compiler to an older standard which they do not advise to do. I have kept the code unchanged for now but we could remove it.