### PR TITLE
Move part of CMakeLists.txt to src/CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,92 +31,7 @@ include(GNUInstallDirs)
 
 add_link_options(LINKER:--disable-new-dtags)
 
-#flcl-fortran library
-add_library(flcl-fortran
-    OBJECT
-        src/flcl-types-f.f90
-        src/flcl-ndarray-f.f90
-        src/flcl-view-f.f90
-        src/flcl-dualview-f.f90
-        src/flcl-util-strings-f.f90
-        src/flcl-f.f90
-        src/flcl-util-kokkos-f.f90
-)
-# standards compliance section
-# There is no CMake function to enforce the language standard in Fortran.
-# See https://gitlab.kitware.com/cmake/cmake/-/issues/22235
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
-    # fully enable F2008, per IBM article: https://www.ibm.com/docs/en/xl-fortran-linux/16.1.1?topic=scenarios-compiling-fortran-2008-programs
-    # also enable polymorphic feature (-qxlf2003=polymorphic) to support the view/dualview types to enable type disambiguation in generic interfaces
-    target_compile_options(flcl-fortran PRIVATE -qxlf2003=polymorphic -qlanglvl=2008std -qnodirective -qnoescape -qfloat=nomaf:rndsngl:nofold -qnoswapomp -qstrictieeemod -qsuppress=1501-510 )
-endif()
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(flcl-fortran PRIVATE -std=f2008)
-endif()
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-    target_compile_options(flcl-fortran PRIVATE -std08)
-endif()
-target_include_directories(flcl-fortran
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
-    INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
-)
-set_target_properties(
-    flcl-fortran
-    PROPERTIES
-        Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
-)
-
-#flcl-cxx library
-add_library(flcl-cxx
-    OBJECT
-        src/flcl-cxx.cpp
-        src/flcl-util-cxx.cpp
-)
-set(flcl-cxx-public-headers
-    ${PROJECT_SOURCE_DIR}/src/flcl-cxx.hpp
-    ${PROJECT_SOURCE_DIR}/src/flcl-types-cxx.hpp
-    ${PROJECT_SOURCE_DIR}/src/flcl-util-cxx.h
-)
-set_property(TARGET flcl-cxx PROPERTY CXX_STANDARD 14)
-set_target_properties(flcl-cxx PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
-target_link_libraries(flcl-cxx
-    PRIVATE
-        Kokkos::kokkos
-)
-
-add_library(flcl
-    STATIC
-        $<TARGET_OBJECTS:flcl-fortran>
-        $<TARGET_OBJECTS:flcl-cxx>
-)
-set_target_properties(flcl PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
-target_include_directories(flcl
-    INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-target_link_libraries(flcl
-    INTERFACE
-    Kokkos::kokkos
-)
-
-# add parallelism library link flags in kokkos > 3.1
-if (Kokkos_VERSION VERSION_GREATER 3.1)
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-        target_link_options(flcl INTERFACE -qopenmp PUBLIC -qopenmp)
-    endif()
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-        target_link_options(flcl INTERFACE -fopenmp PUBLIC -fopenmp)
-    endif()
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
-        target_link_options(flcl INTERFACE -qopenmp PUBLIC -qopenmp)
-    endif()
-endif()
-
-#add flcl library
-add_library(flcl::flcl ALIAS flcl)
+add_subdirectory(src)
 
 #installation section
 include(CMakePackageConfigHelpers)
@@ -154,7 +69,7 @@ install(
 )
 
 # install flcl module files in include directory
-install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/src/mod/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 #unit testing section and toggle
 if(FLCL_BUILD_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,86 @@
+#flcl-fortran library
+add_library(flcl-fortran
+    OBJECT
+        flcl-types-f.f90
+        flcl-ndarray-f.f90
+        flcl-view-f.f90
+        flcl-dualview-f.f90
+        flcl-util-strings-f.f90
+        flcl-f.f90
+        flcl-util-kokkos-f.f90
+)
+# standards compliance section
+# There is no CMake function to enforce the language standard in Fortran.
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/22235
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
+    # fully enable F2008, per IBM article: https://www.ibm.com/docs/en/xl-fortran-linux/16.1.1?topic=scenarios-compiling-fortran-2008-programs
+    # also enable polymorphic feature (-qxlf2003=polymorphic) to support the view/dualview types to enable type disambiguation in generic interfaces
+    target_compile_options(flcl-fortran PRIVATE -qxlf2003=polymorphic -qlanglvl=2008std -qnodirective -qnoescape -qfloat=nomaf:rndsngl:nofold -qnoswapomp -qstrictieeemod -qsuppress=1501-510 )
+endif()
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    target_compile_options(flcl-fortran PRIVATE -std=f2008)
+endif()
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+    target_compile_options(flcl-fortran PRIVATE -std08)
+endif()
+target_include_directories(flcl-fortran
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+)
+set_target_properties(
+    flcl-fortran
+    PROPERTIES
+        Fortran_MODULE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/mod"
+)
+
+#flcl-cxx library
+add_library(flcl-cxx
+    OBJECT
+        flcl-cxx.cpp
+        flcl-util-cxx.cpp
+)
+set(flcl-cxx-public-headers
+    ${PROJECT_SOURCE_DIR}/src/flcl-cxx.hpp
+    ${PROJECT_SOURCE_DIR}/src/flcl-types-cxx.hpp
+    ${PROJECT_SOURCE_DIR}/src/flcl-util-cxx.h
+)
+set_property(TARGET flcl-cxx PROPERTY CXX_STANDARD 14)
+set_target_properties(flcl-cxx PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
+target_link_libraries(flcl-cxx
+    PRIVATE
+        Kokkos::kokkos
+)
+
+add_library(flcl
+    STATIC
+        $<TARGET_OBJECTS:flcl-fortran>
+        $<TARGET_OBJECTS:flcl-cxx>
+)
+set_target_properties(flcl PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
+target_include_directories(flcl
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/mod>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(flcl
+    INTERFACE
+    Kokkos::kokkos
+)
+
+# add parallelism library link flags in kokkos > 3.1
+if (Kokkos_VERSION VERSION_GREATER 3.1)
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+        target_link_options(flcl INTERFACE -qopenmp PUBLIC -qopenmp)
+    endif()
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+        target_link_options(flcl INTERFACE -fopenmp PUBLIC -fopenmp)
+    endif()
+    if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
+        target_link_options(flcl INTERFACE -qopenmp PUBLIC -qopenmp)
+    endif()
+endif()
+
+#add flcl library
+add_library(flcl::flcl ALIAS flcl)


### PR DESCRIPTION
This PR moves code from CMakeLists.txt to src/CMakeLists.txt. A few paths had to be adjusted but nothing else was changed.