### PR TITLE
Update build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if (FLCL_BUILD_EXAMPLES OR FLCL_BUILD_TESTS)
   endif()
 endif()
 
-find_package(Kokkos REQUIRED)
+find_package(Kokkos 4.0 REQUIRED)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,25 +11,18 @@ if (NOT CMAKE_BUILD_TYPE)
 endif()
 
 
-# FIXME This was set in a XL-related commit:
-# https://github.com/kokkos/kokkos-fortran-interop/commit/f232302284400a90410a36edb14f538c20b8a71b
-# We need to check if it is still necessary
-set(BUILD_SHARED_LIBS OFF)
 option(FLCL_BUILD_EXAMPLES "Build examples" ON)
 option(FLCL_BUILD_TESTS "Build tests" ON)
 
-# The tests and the examples need to be built with PIE because they link against GLICXX
-if (FLCL_BUILD_EXAMPLES OR FLCL_BUILD_TESTS)
-  if (NOT CMAKE_POSITION_INDEPENDENT_CODE)
-    message(FATAL_ERROR "Enabling the tests or the examples require configuring with -DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-  endif()
-endif()
+# We need to set CMAKE_POSITION_INDEPENDENT_CODE. Otherwise there is an issue
+# when linking flcl.cxx.cpp.o into libflcl. This is necessary even when
+# building a shared library
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 
 find_package(Kokkos 4.0 REQUIRED)
 
 include(GNUInstallDirs)
-
-add_link_options(LINKER:--disable-new-dtags)
 
 add_subdirectory(src)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To check out the source code for FLCL,
 
 # Requirements
 - Compiler suite with both Fortran (F08) and C++ (C++11) support.
-- A build of [Kokkos](https://github.com/kokkos/kokkos) 3.x built with the compiler suite above.
+- A build of [Kokkos](https://github.com/kokkos/kokkos) 4.x built with the compiler suite above.
 
 # Feedback
 Please raise an issue using the [GitHub issues](https://github.com/kokkos/kokkos-fortran-interop/issues)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,7 +54,6 @@ target_link_libraries(flcl-cxx
 )
 
 add_library(flcl
-    STATIC
         $<TARGET_OBJECTS:flcl-fortran>
         $<TARGET_OBJECTS:flcl-cxx>
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,18 +69,5 @@ target_link_libraries(flcl
     Kokkos::kokkos
 )
 
-# add parallelism library link flags in kokkos > 3.1
-if (Kokkos_VERSION VERSION_GREATER 3.1)
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-        target_link_options(flcl INTERFACE -qopenmp PUBLIC -qopenmp)
-    endif()
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-        target_link_options(flcl INTERFACE -fopenmp PUBLIC -fopenmp)
-    endif()
-    if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
-        target_link_options(flcl INTERFACE -qopenmp PUBLIC -qopenmp)
-    endif()
-endif()
-
 #add flcl library
 add_library(flcl::flcl ALIAS flcl)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ set(flcl-cxx-public-headers
     ${PROJECT_SOURCE_DIR}/src/flcl-types-cxx.hpp
     ${PROJECT_SOURCE_DIR}/src/flcl-util-cxx.h
 )
-set_property(TARGET flcl-cxx PROPERTY CXX_STANDARD 14)
+set_property(TARGET flcl-cxx PROPERTY CXX_STANDARD 17)
 set_target_properties(flcl-cxx PROPERTIES PUBLIC_HEADER "${flcl-cxx-public-headers}")
 target_link_libraries(flcl-cxx
     PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,3 @@
-macro(remove_link_flag_from_target _target _flag)
-    get_target_property(_target_link_flags ${_target} LINK_OPTIONS)
-    if(_target_link_flags)
-        list(REMOVE_ITEM _target_link_flags ${_flag})
-        set_target_properties(${_target} PROPERTIES LINK_OPTIONS "${_target_link_flags}")
-    endif()
-endmacro()
-
 add_library(flcl-testlib-fortran
     OBJECT
         flcl-test-f.F90
@@ -101,6 +93,4 @@ foreach(file ${files})
  	set_tests_properties(${file_without_ext}
  		PROPERTIES
         TIMEOUT 120)
-
-    remove_link_flag_from_target(${file_without_ext} -arch=sm_70)
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(flcl-testlib-cxx
 )
 
 add_library(flcl-testlib
-    #STATIC
         $<TARGET_OBJECTS:flcl-testlib-fortran>
         $<TARGET_OBJECTS:flcl-testlib-cxx>
 )
@@ -90,10 +89,6 @@ foreach(file ${files})
     if (CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
         set_target_properties(${file_without_ext} PROPERTIES LINKER_LANGUAGE Fortran)
     endif()
-    set(RPATHS "$ENV{LD_LIBRARY_PATH}")
-	set_target_properties(${file_without_ext} PROPERTIES 
-						  BUILD_WITH_INSTALL_RPATH True
-						  INSTALL_RPATH "${RPATHS}")
  	target_link_libraries(${file_without_ext} ${PROJECT_LIBS} flcl::flcl flcl-testlib)
     add_test(${file_without_ext} ${file_without_ext})
 	# set_target_properties(${file_without_ext} PROPERTIES LINKER_LANGUAGE Fortran) 


### PR DESCRIPTION
This PR contains several unrelated changes:

- Change the requirement from Kokkos 3.0 to 4.0
- Require C++17 to align with Kokkos
- Do not add OpenMP flags
- Add support for shared library
- Don't remove architecture flags when compiling for V100