### PR TITLE
Remove prefix string for kokkos_print_configuration

### DIFF
--- a/src/flcl-util-cxx.cpp
+++ b/src/flcl-util-cxx.cpp
@@ -55,17 +55,15 @@ extern "C" {
     Kokkos::finalize();
   }
 
-  void c_kokkos_print_configuration(const char* prepend_name_in, const char* file_name_in) {
+  void c_kokkos_print_configuration(const char* file_name_in) {
 
-    std::string prepend_name( prepend_name_in );
     std::string file_name( file_name_in );
-    std::string output_filename = prepend_name + file_name;
-    std::ofstream kokkos_output_file ( output_filename );
+    std::ofstream kokkos_output_file ( file_name );
     if ( kokkos_output_file.is_open()) {
       Kokkos::print_configuration( kokkos_output_file, true );
       kokkos_output_file.close();
     } else {
-      std::cout << "Could not open filename " << output_filename;
+      std::cout << "Could not open filename " << file_name;
       std::cout << " to dump Kokkos::print_configuration to." << std::endl;
     }
     

--- a/src/flcl-util-cxx.h
+++ b/src/flcl-util-cxx.h
@@ -46,7 +46,7 @@ extern "C"
 void c_kokkos_initialize(int *argc, char **argv);
 void c_kokkos_initialize_without_args(void);
 void c_kokkos_finalize(void);
-void c_kokkos_print_configuration(const char* prepend_name_in, const char* file_name_in);
+void c_kokkos_print_configuration(const char* file_name_in);
 
 #ifdef __cplusplus
 bool c_kokkos_is_initialized(void);

--- a/src/flcl-util-kokkos-f.f90
+++ b/src/flcl-util-kokkos-f.f90
@@ -81,11 +81,10 @@ module flcl_util_kokkos_mod
 !!! kokkos library helper routine interfaces
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   interface
-    subroutine f_kokkos_print_configuration( prepend_name_in, file_name_in ) &
+    subroutine f_kokkos_print_configuration( file_name_in ) &
       & bind(c, name='c_kokkos_print_configuration')
       use, intrinsic :: iso_c_binding
       implicit none
-      character(kind=c_char), intent(in) :: prepend_name_in(*)
       character(kind=c_char), intent(in) :: file_name_in(*)
     end subroutine f_kokkos_print_configuration
   end interface
@@ -159,20 +158,17 @@ module flcl_util_kokkos_mod
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! kokkos library helper routine implementations
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  subroutine kokkos_print_configuration( prepend_name_in, file_name_in )
+  subroutine kokkos_print_configuration( file_name_in )
     use, intrinsic :: iso_c_binding
     use flcl_util_strings_mod, only: char_add_null
     implicit none
 
-    character(len=*), intent(in) :: prepend_name_in
     character(len=*), intent(in) :: file_name_in
-    character(len=:, kind=c_char), allocatable, target :: prepend_name_out
     character(len=:, kind=c_char), allocatable, target :: file_name_out
 
-    call char_add_null( prepend_name_in, prepend_name_out )
     call char_add_null( file_name_in, file_name_out )
 
-    call f_kokkos_print_configuration( prepend_name_out, file_name_out )
+    call f_kokkos_print_configuration( file_name_out )
 
   end subroutine kokkos_print_configuration
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/test/test_from_ndarray_c32_1d.f90
+++ b/test/test_from_ndarray_c32_1d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c32_1d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c32_1d.f90
+++ b/test/test_from_ndarray_c32_1d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c32_1d()
   

--- a/test/test_from_ndarray_c32_2d.f90
+++ b/test/test_from_ndarray_c32_2d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c32_2d()
   

--- a/test/test_from_ndarray_c32_2d.f90
+++ b/test/test_from_ndarray_c32_2d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c32_2d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c32_3d.f90
+++ b/test/test_from_ndarray_c32_3d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c32_3d()
   

--- a/test/test_from_ndarray_c32_3d.f90
+++ b/test/test_from_ndarray_c32_3d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c32_3d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c32_4d.f90
+++ b/test/test_from_ndarray_c32_4d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c32_4d()
   

--- a/test/test_from_ndarray_c32_4d.f90
+++ b/test/test_from_ndarray_c32_4d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c32_4d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c32_5d.f90
+++ b/test/test_from_ndarray_c32_5d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c32_5d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c32_5d.f90
+++ b/test/test_from_ndarray_c32_5d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c32_5d()
   

--- a/test/test_from_ndarray_c32_6d.f90
+++ b/test/test_from_ndarray_c32_6d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c32_6d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c32_6d.f90
+++ b/test/test_from_ndarray_c32_6d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c32_6d()
   

--- a/test/test_from_ndarray_c32_7d.f90
+++ b/test/test_from_ndarray_c32_7d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c32_7d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c32_7d.f90
+++ b/test/test_from_ndarray_c32_7d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c32_7d()
   

--- a/test/test_from_ndarray_c64_1d.f90
+++ b/test/test_from_ndarray_c64_1d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c64_1d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c64_1d.f90
+++ b/test/test_from_ndarray_c64_1d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c64_1d()
   

--- a/test/test_from_ndarray_c64_2d.f90
+++ b/test/test_from_ndarray_c64_2d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c64_2d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c64_2d.f90
+++ b/test/test_from_ndarray_c64_2d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c64_2d()
   

--- a/test/test_from_ndarray_c64_3d.f90
+++ b/test/test_from_ndarray_c64_3d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c64_3d()
   

--- a/test/test_from_ndarray_c64_3d.f90
+++ b/test/test_from_ndarray_c64_3d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c64_3d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c64_4d.f90
+++ b/test/test_from_ndarray_c64_4d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c64_4d()
   

--- a/test/test_from_ndarray_c64_4d.f90
+++ b/test/test_from_ndarray_c64_4d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c64_4d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c64_5d.f90
+++ b/test/test_from_ndarray_c64_5d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c64_5d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c64_5d.f90
+++ b/test/test_from_ndarray_c64_5d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c64_5d()
   

--- a/test/test_from_ndarray_c64_6d.f90
+++ b/test/test_from_ndarray_c64_6d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c64_6d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_c64_6d.f90
+++ b/test/test_from_ndarray_c64_6d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c64_6d()
   

--- a/test/test_from_ndarray_c64_7d.f90
+++ b/test/test_from_ndarray_c64_7d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_c64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_c64_7d()
   

--- a/test/test_from_ndarray_c64_7d.f90
+++ b/test/test_from_ndarray_c64_7d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_c64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_c64_7d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_1d.f90
+++ b/test/test_from_ndarray_i32_1d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_i32_1d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_1d.f90
+++ b/test/test_from_ndarray_i32_1d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_i32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_i32_1d()
   

--- a/test/test_from_ndarray_i32_2d.f90
+++ b/test/test_from_ndarray_i32_2d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_i32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_i32_2d()
   

--- a/test/test_from_ndarray_i32_2d.f90
+++ b/test/test_from_ndarray_i32_2d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_i32_2d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_3d.f90
+++ b/test/test_from_ndarray_i32_3d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_i32_3d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_3d.f90
+++ b/test/test_from_ndarray_i32_3d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_i32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_i32_3d()
   

--- a/test/test_from_ndarray_i32_4d.f90
+++ b/test/test_from_ndarray_i32_4d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_i32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_i32_4d()
   

--- a/test/test_from_ndarray_i32_4d.f90
+++ b/test/test_from_ndarray_i32_4d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_i32_4d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_5d.f90
+++ b/test/test_from_ndarray_i32_5d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_i32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_i32_5d()
   

--- a/test/test_from_ndarray_i32_5d.f90
+++ b/test/test_from_ndarray_i32_5d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_i32_5d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_6d.f90
+++ b/test/test_from_ndarray_i32_6d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_i32_6d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_6d.f90
+++ b/test/test_from_ndarray_i32_6d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_i32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_i32_6d()
   

--- a/test/test_from_ndarray_i32_7d.f90
+++ b/test/test_from_ndarray_i32_7d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_i32_7d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i32_7d.f90
+++ b/test/test_from_ndarray_i32_7d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_i32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_i32_7d()
   

--- a/test/test_from_ndarray_i64_1d.f90
+++ b/test/test_from_ndarray_i64_1d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_i64_1d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i64_2d.f90
+++ b/test/test_from_ndarray_i64_2d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_i64_2d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i64_3d.f90
+++ b/test/test_from_ndarray_i64_3d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_i64_3d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i64_4d.f90
+++ b/test/test_from_ndarray_i64_4d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_i64_4d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i64_5d.f90
+++ b/test/test_from_ndarray_i64_5d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_i64_5d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i64_6d.f90
+++ b/test/test_from_ndarray_i64_6d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_i64_6d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_i64_7d.f90
+++ b/test/test_from_ndarray_i64_7d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_i64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_i64_7d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_1d.f90
+++ b/test/test_from_ndarray_l_1d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_l_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_l_1d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_1d.f90
+++ b/test/test_from_ndarray_l_1d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_l_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_l_1d()
   

--- a/test/test_from_ndarray_l_2d.f90
+++ b/test/test_from_ndarray_l_2d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_l_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_l_2d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_2d.f90
+++ b/test/test_from_ndarray_l_2d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_l_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_l_2d()
   

--- a/test/test_from_ndarray_l_3d.f90
+++ b/test/test_from_ndarray_l_3d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_l_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_l_3d()
   

--- a/test/test_from_ndarray_l_3d.f90
+++ b/test/test_from_ndarray_l_3d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_l_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_l_3d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_4d.f90
+++ b/test/test_from_ndarray_l_4d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_l_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_l_4d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_4d.f90
+++ b/test/test_from_ndarray_l_4d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_l_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_l_4d()
   

--- a/test/test_from_ndarray_l_5d.f90
+++ b/test/test_from_ndarray_l_5d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_l_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_l_5d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_5d.f90
+++ b/test/test_from_ndarray_l_5d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_l_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_l_5d()
   

--- a/test/test_from_ndarray_l_6d.f90
+++ b/test/test_from_ndarray_l_6d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_l_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_l_6d()
   

--- a/test/test_from_ndarray_l_6d.f90
+++ b/test/test_from_ndarray_l_6d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_l_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_l_6d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_7d.f90
+++ b/test/test_from_ndarray_l_7d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_l_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_l_7d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_l_7d.f90
+++ b/test/test_from_ndarray_l_7d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_l_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_l_7d()
   

--- a/test/test_from_ndarray_r32_1d.f90
+++ b/test/test_from_ndarray_r32_1d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r32_1d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r32_1d.f90
+++ b/test/test_from_ndarray_r32_1d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r32_1d()
   

--- a/test/test_from_ndarray_r32_2d.f90
+++ b/test/test_from_ndarray_r32_2d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r32_2d()
   

--- a/test/test_from_ndarray_r32_2d.f90
+++ b/test/test_from_ndarray_r32_2d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r32_2d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r32_3d.f90
+++ b/test/test_from_ndarray_r32_3d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r32_3d()
   

--- a/test/test_from_ndarray_r32_3d.f90
+++ b/test/test_from_ndarray_r32_3d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r32_3d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r32_4d.f90
+++ b/test/test_from_ndarray_r32_4d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r32_4d()
   

--- a/test/test_from_ndarray_r32_4d.f90
+++ b/test/test_from_ndarray_r32_4d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r32_4d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r32_5d.f90
+++ b/test/test_from_ndarray_r32_5d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r32_5d()
   

--- a/test/test_from_ndarray_r32_5d.f90
+++ b/test/test_from_ndarray_r32_5d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r32_5d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r32_6d.f90
+++ b/test/test_from_ndarray_r32_6d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r32_6d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r32_6d.f90
+++ b/test/test_from_ndarray_r32_6d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r32_6d()
   

--- a/test/test_from_ndarray_r32_7d.f90
+++ b/test/test_from_ndarray_r32_7d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r32_7d()
   

--- a/test/test_from_ndarray_r32_7d.f90
+++ b/test/test_from_ndarray_r32_7d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r32_7d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r64_1d.f90
+++ b/test/test_from_ndarray_r64_1d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r64_1d()
   

--- a/test/test_from_ndarray_r64_1d.f90
+++ b/test/test_from_ndarray_r64_1d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r64_1d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r64_2d.f90
+++ b/test/test_from_ndarray_r64_2d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r64_2d()
   

--- a/test/test_from_ndarray_r64_2d.f90
+++ b/test/test_from_ndarray_r64_2d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r64_2d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r64_3d.f90
+++ b/test/test_from_ndarray_r64_3d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r64_3d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r64_3d.f90
+++ b/test/test_from_ndarray_r64_3d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r64_3d()
   

--- a/test/test_from_ndarray_r64_4d.f90
+++ b/test/test_from_ndarray_r64_4d.f90
@@ -51,7 +51,7 @@ program test_from_ndarray_r64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      ! call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_from_ndarray_r64_4d()
   

--- a/test/test_from_ndarray_r64_4d.f90
+++ b/test/test_from_ndarray_r64_4d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-kokkos.out')
-  
       ierr = test_from_ndarray_r64_4d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r64_5d.f90
+++ b/test/test_from_ndarray_r64_5d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_r64_5d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r64_6d.f90
+++ b/test/test_from_ndarray_r64_6d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_r64_6d()
   
       call kokkos_finalize()

--- a/test/test_from_ndarray_r64_7d.f90
+++ b/test/test_from_ndarray_r64_7d.f90
@@ -51,8 +51,6 @@ program test_from_ndarray_r64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_from_ndarray_r64_7d()
   
       call kokkos_finalize()

--- a/test/test_kokkos_allocate_dualview_i32_1d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_1d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i32_1d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i32_2d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_2d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i32_2d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i32_3d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_3d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i32_3d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i32_4d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_4d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i32_4d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i32_5d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_5d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i32_5d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i32_6d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_6d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i32_6d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i32_7d.f90
+++ b/test/test_kokkos_allocate_dualview_i32_7d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i32_7d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i64_1d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_1d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i64_1d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i64_2d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_2d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i64_2d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i64_3d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_3d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i64_3d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i64_4d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_4d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i64_4d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i64_5d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_5d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i64_5d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i64_6d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_6d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i64_6d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_i64_7d.f90
+++ b/test/test_kokkos_allocate_dualview_i64_7d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_i64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_i64_7d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_l_1d.f90
+++ b/test/test_kokkos_allocate_dualview_l_1d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_l_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_l_1d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_l_2d.f90
+++ b/test/test_kokkos_allocate_dualview_l_2d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_l_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_l_2d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_l_3d.f90
+++ b/test/test_kokkos_allocate_dualview_l_3d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_l_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_l_3d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_l_4d.f90
+++ b/test/test_kokkos_allocate_dualview_l_4d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_l_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_l_4d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_l_5d.f90
+++ b/test/test_kokkos_allocate_dualview_l_5d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_l_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_l_5d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_l_6d.f90
+++ b/test/test_kokkos_allocate_dualview_l_6d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_l_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_l_6d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_l_7d.f90
+++ b/test/test_kokkos_allocate_dualview_l_7d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_l_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_l_7d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r32_1d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_1d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r32_1d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r32_2d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_2d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r32_2d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r32_3d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_3d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r32_3d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r32_4d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_4d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r32_4d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r32_5d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_5d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r32_5d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r32_6d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_6d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r32_6d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r32_7d.f90
+++ b/test/test_kokkos_allocate_dualview_r32_7d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r32_7d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r64_1d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_1d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r64_1d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r64_2d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_2d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r64_2d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r64_3d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_3d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r64_3d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r64_4d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_4d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r64_4d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r64_5d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_5d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r64_5d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r64_6d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_6d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r64_6d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_dualview_r64_7d.f90
+++ b/test/test_kokkos_allocate_dualview_r64_7d.f90
@@ -53,7 +53,7 @@ program test_kokkos_allocate_dualview_r64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      call kokkos_print_configuration('flcl-test-', 'kokkos.out')
+      call kokkos_print_configuration('flcl-test-kokkos.out')
   
       ierr = test_kokkos_allocate_dualview_r64_7d()
       write(*,*)'ierr ',ierr

--- a/test/test_kokkos_allocate_view_i32_1d.f90
+++ b/test/test_kokkos_allocate_view_i32_1d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i32_1d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i32_2d.f90
+++ b/test/test_kokkos_allocate_view_i32_2d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i32_2d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i32_3d.f90
+++ b/test/test_kokkos_allocate_view_i32_3d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i32_3d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i32_4d.f90
+++ b/test/test_kokkos_allocate_view_i32_4d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i32_4d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i32_5d.f90
+++ b/test/test_kokkos_allocate_view_i32_5d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i32_5d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i32_6d.f90
+++ b/test/test_kokkos_allocate_view_i32_6d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i32_6d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i32_7d.f90
+++ b/test/test_kokkos_allocate_view_i32_7d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i32_7d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i64_1d.f90
+++ b/test/test_kokkos_allocate_view_i64_1d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i64_1d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i64_2d.f90
+++ b/test/test_kokkos_allocate_view_i64_2d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i64_2d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i64_3d.f90
+++ b/test/test_kokkos_allocate_view_i64_3d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i64_3d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i64_4d.f90
+++ b/test/test_kokkos_allocate_view_i64_4d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i64_4d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i64_5d.f90
+++ b/test/test_kokkos_allocate_view_i64_5d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i64_5d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i64_6d.f90
+++ b/test/test_kokkos_allocate_view_i64_6d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i64_6d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_i64_7d.f90
+++ b/test/test_kokkos_allocate_view_i64_7d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_i64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_i64_7d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_l_1d.f90
+++ b/test/test_kokkos_allocate_view_l_1d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_l_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_l_1d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_l_2d.f90
+++ b/test/test_kokkos_allocate_view_l_2d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_l_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_l_2d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_l_3d.f90
+++ b/test/test_kokkos_allocate_view_l_3d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_l_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_l_3d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_l_4d.f90
+++ b/test/test_kokkos_allocate_view_l_4d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_l_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_l_4d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_l_5d.f90
+++ b/test/test_kokkos_allocate_view_l_5d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_l_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_l_5d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_l_6d.f90
+++ b/test/test_kokkos_allocate_view_l_6d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_l_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_l_6d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_l_7d.f90
+++ b/test/test_kokkos_allocate_view_l_7d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_l_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_l_7d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r32_1d.f90
+++ b/test/test_kokkos_allocate_view_r32_1d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r32_1d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r32_2d.f90
+++ b/test/test_kokkos_allocate_view_r32_2d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r32_2d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r32_3d.f90
+++ b/test/test_kokkos_allocate_view_r32_3d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r32_3d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r32_4d.f90
+++ b/test/test_kokkos_allocate_view_r32_4d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r32_4d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r32_5d.f90
+++ b/test/test_kokkos_allocate_view_r32_5d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r32_5d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r32_6d.f90
+++ b/test/test_kokkos_allocate_view_r32_6d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r32_6d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r32_7d.f90
+++ b/test/test_kokkos_allocate_view_r32_7d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r32_7d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r64_1d.f90
+++ b/test/test_kokkos_allocate_view_r64_1d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r64_1d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r64_2d.f90
+++ b/test/test_kokkos_allocate_view_r64_2d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r64_2d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r64_3d.f90
+++ b/test/test_kokkos_allocate_view_r64_3d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r64_3d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r64_4d.f90
+++ b/test/test_kokkos_allocate_view_r64_4d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r64_4d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r64_5d.f90
+++ b/test/test_kokkos_allocate_view_r64_5d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r64_5d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r64_6d.f90
+++ b/test/test_kokkos_allocate_view_r64_6d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r64_6d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_kokkos_allocate_view_r64_7d.f90
+++ b/test/test_kokkos_allocate_view_r64_7d.f90
@@ -53,8 +53,6 @@ program test_kokkos_allocate_view_r64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_kokkos_allocate_view_r64_7d()
       write(*,*)'ierr ',ierr
   

--- a/test/test_to_ndarray_c32_1d.f90
+++ b/test/test_to_ndarray_c32_1d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c32_1d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c32_2d.f90
+++ b/test/test_to_ndarray_c32_2d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c32_2d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c32_3d.f90
+++ b/test/test_to_ndarray_c32_3d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c32_3d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c32_4d.f90
+++ b/test/test_to_ndarray_c32_4d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c32_4d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c32_5d.f90
+++ b/test/test_to_ndarray_c32_5d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c32_5d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c32_6d.f90
+++ b/test/test_to_ndarray_c32_6d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c32_6d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c32_7d.f90
+++ b/test/test_to_ndarray_c32_7d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c32_7d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c64_1d.f90
+++ b/test/test_to_ndarray_c64_1d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c64_1d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c64_2d.f90
+++ b/test/test_to_ndarray_c64_2d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c64_2d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c64_3d.f90
+++ b/test/test_to_ndarray_c64_3d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c64_3d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c64_4d.f90
+++ b/test/test_to_ndarray_c64_4d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c64_4d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c64_5d.f90
+++ b/test/test_to_ndarray_c64_5d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c64_5d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c64_6d.f90
+++ b/test/test_to_ndarray_c64_6d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c64_6d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_c64_7d.f90
+++ b/test/test_to_ndarray_c64_7d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_c64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_c64_7d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i32_1d.f90
+++ b/test/test_to_ndarray_i32_1d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i32_1d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i32_2d.f90
+++ b/test/test_to_ndarray_i32_2d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i32_2d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i32_3d.f90
+++ b/test/test_to_ndarray_i32_3d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i32_3d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i32_4d.f90
+++ b/test/test_to_ndarray_i32_4d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i32_4d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i32_5d.f90
+++ b/test/test_to_ndarray_i32_5d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i32_5d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i32_6d.f90
+++ b/test/test_to_ndarray_i32_6d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i32_6d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i32_7d.f90
+++ b/test/test_to_ndarray_i32_7d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i32_7d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i64_1d.f90
+++ b/test/test_to_ndarray_i64_1d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i64_1d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i64_2d.f90
+++ b/test/test_to_ndarray_i64_2d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i64_2d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i64_3d.f90
+++ b/test/test_to_ndarray_i64_3d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i64_3d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i64_4d.f90
+++ b/test/test_to_ndarray_i64_4d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i64_4d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i64_5d.f90
+++ b/test/test_to_ndarray_i64_5d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i64_5d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i64_6d.f90
+++ b/test/test_to_ndarray_i64_6d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i64_6d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_i64_7d.f90
+++ b/test/test_to_ndarray_i64_7d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_i64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_i64_7d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_l_1d.f90
+++ b/test/test_to_ndarray_l_1d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_l_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_l_1d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_l_2d.f90
+++ b/test/test_to_ndarray_l_2d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_l_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_l_2d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_l_3d.f90
+++ b/test/test_to_ndarray_l_3d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_l_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_l_3d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_l_4d.f90
+++ b/test/test_to_ndarray_l_4d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_l_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_l_4d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_l_5d.f90
+++ b/test/test_to_ndarray_l_5d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_l_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_l_5d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_l_6d.f90
+++ b/test/test_to_ndarray_l_6d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_l_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_l_6d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_l_7d.f90
+++ b/test/test_to_ndarray_l_7d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_l_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_l_7d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r32_1d.f90
+++ b/test/test_to_ndarray_r32_1d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r32_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r32_1d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r32_2d.f90
+++ b/test/test_to_ndarray_r32_2d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r32_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r32_2d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r32_3d.f90
+++ b/test/test_to_ndarray_r32_3d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r32_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r32_3d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r32_4d.f90
+++ b/test/test_to_ndarray_r32_4d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r32_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r32_4d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r32_5d.f90
+++ b/test/test_to_ndarray_r32_5d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r32_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r32_5d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r32_6d.f90
+++ b/test/test_to_ndarray_r32_6d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r32_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r32_6d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r32_7d.f90
+++ b/test/test_to_ndarray_r32_7d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r32_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r32_7d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r64_1d.f90
+++ b/test/test_to_ndarray_r64_1d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r64_1d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r64_1d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r64_2d.f90
+++ b/test/test_to_ndarray_r64_2d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r64_2d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r64_2d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r64_3d.f90
+++ b/test/test_to_ndarray_r64_3d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r64_3d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r64_3d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r64_4d.f90
+++ b/test/test_to_ndarray_r64_4d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r64_4d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r64_4d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r64_5d.f90
+++ b/test/test_to_ndarray_r64_5d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r64_5d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r64_5d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r64_6d.f90
+++ b/test/test_to_ndarray_r64_6d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r64_6d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r64_6d()
   
       call kokkos_finalize()

--- a/test/test_to_ndarray_r64_7d.f90
+++ b/test/test_to_ndarray_r64_7d.f90
@@ -51,8 +51,6 @@ program test_to_ndarray_r64_7d_main
 
     if ( kokkos_is_initialized() ) then
       
-      ! call kokkos_print_configuration('flcl-test-', 'kokkos.out')
-  
       ierr = test_to_ndarray_r64_7d()
   
       call kokkos_finalize()


### PR DESCRIPTION
Currently `kokkos_print_configuration` takes two inputs: the prefix and the file name. The inputs are concatenated to create the name of the output file in which the configuration is written. I propose to change `kokkos_print_configuration` to take a single argument, the output file name. 
```fortran
! old function
call kokkos_print_configuration('prefix-', 'kokkos.out')
! new function
call kokkos_print_configuration('prefix-kokkos.out')
```