### PR TITLE
Simplify macros used in the tests

### DIFF
--- a/test/flcl-test-f.F90
+++ b/test/flcl-test-f.F90
@@ -35,18 +35,8 @@
 ! (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if defined(__INTEL_COMPILER)
 #define FLCL_REALPART(X) X%RE
 #define FLCL_IMAGPART(X) X%IM
-#elif defined(__xlc__)
-#define FLCL_REALPART(X) X%RE
-#define FLCL_IMAGPART(X) X%IM
-#elif defined(__GNUC__)
-#define FLCL_REALPART(X) real(real(X))
-#define FLCL_IMAGPART(X) real(aimag(X))
-#else
-#error "Untested compiler, please raise an issue at: https://github.com/kokkos/kokkos-fortran-interop/issues"
-#endif
 
 module flcl_test_f_mod
   use, intrinsic :: iso_c_binding


### PR DESCRIPTION
https://github.com/kokkos/kokkos-fortran-interop/commit/88f31e6273b6e5757634354d633440336caa0453 introduced two macros `FLCL_REALPART` and `FLCL_IMAGPART` to get the real/imaginary part of complex numbers. There is no explanation why this is done.  `%RE` and `%IM` are valid fortran. I checked gfortran and there is no issue using `%RE` and `%IM`. This PR fixes the problem reported in https://github.com/kokkos/kokkos-fortran-interop/issues/76